### PR TITLE
Fix: Longer tracks start from beginning in preview mode

### DIFF
--- a/packages/front/src/Preview.js
+++ b/packages/front/src/Preview.js
@@ -37,12 +37,14 @@ class Preview extends Component {
       previousDoubleClickStarted: false,
       cartFilter: '',
       embeddingMissing: true,
+      initialPositionSet: false,
     }
     if (window.AudioContext !== undefined) {
       this.audioContext = new AudioContext()
     }
 
     this.setVolume = this.setVolume.bind(this)
+    this.handleInitialPosition = this.handleInitialPosition.bind(this)
 
     const actionHandlers = [
       ['play', this.setPlaying.bind(this, true)],
@@ -89,6 +91,7 @@ class Preview extends Component {
       totalDuration: undefined,
       mp3Preview: preview,
       previewUrl: undefined,
+      initialPositionSet: false,
     })
 
     let url = preview.url
@@ -231,6 +234,27 @@ class Preview extends Component {
   setVolume(volume) {
     this.setState({ volume: volume * 100 })
     this.getPlayer().volume = volume
+  }
+
+  handleInitialPosition() {
+    if (this.state.initialPositionSet) return
+
+    const mp3Preview = this.state.mp3Preview
+    if (!mp3Preview) return
+
+    const shouldSkip = this.getShouldSkip()
+    const previewDetails = this.getPreviewDetails()
+
+    if (shouldSkip) {
+      this.setState({
+        position: previewDetails.start_ms,
+        initialPositionSet: true,
+      })
+      this.getPlayer().currentTime = (previewDetails.start_ms - mp3Preview.start_ms) / 1000
+    } else {
+      this.setState({ initialPositionSet: true })
+    }
+    this.play()
   }
 
   scan(step) {
@@ -616,20 +640,8 @@ class Preview extends Component {
                 onPlay={async () => {
                   await this.props.markHeard(currentTrack.id)
                 }}
-                onPlaying={() => {
-                  if (!shouldSkip && this.state.position === 0) {
-                    this.play()
-                  }
-                }}
-                onCanPlayThrough={() => {
-                  if (shouldSkip && this.state.position === 0) {
-                    this.setState({
-                      position: previewDetails.start_ms,
-                    })
-                    this.getPlayer().currentTime = (previewDetails.start_ms - mp3Preview.start_ms) / 1000
-                  }
-                  this.play()
-                }}
+                onPlaying={() => this.handleInitialPosition()}
+                onCanPlayThrough={() => this.handleInitialPosition()}
                 onPause={() => this.setPlaying(false)}
                 onTimeUpdate={({ currentTarget: { currentTime } }) => {
                   this.setState({ position: currentTime * 1000 })


### PR DESCRIPTION
This PR fixes a bug in the frontend audio player where longer tracks would always start playback from the beginning when in preview mode, even when they were supposed to skip to a specific starting position.

The issue was caused by a race condition between the audio element's `onTimeUpdate` event and the `onCanPlayThrough`/`onPlaying` events. If `onTimeUpdate` fired first (which it often did), it would update the `position` state to a non-zero value, causing the subsequent check for `position === 0` in the skip logic to fail.

Key changes:
- Added `initialPositionSet` to the `Preview` component's state.
- Created `handleInitialPosition()` to manage the initial seek and playback start.
- Updated the `audio` element's `onPlaying` and `onCanPlayThrough` handlers to use `handleInitialPosition()`.
- Reset `initialPositionSet` to `false` in `updateTrack()` whenever a new track or preview is loaded.

---
*PR created automatically by Jules for task [6422797814779237111](https://jules.google.com/task/6422797814779237111) started by @gadgetmies*