### PR TITLE
fix: cart filter input swallowed keystrokes; align with global search syntax

### DIFF
--- a/packages/back/routes/shared/db/cart.js
+++ b/packages/back/routes/shared/db/cart.js
@@ -199,8 +199,8 @@ module.exports.queryCartDetails = async (
                   NATURAL JOIN JSON_TO_RECORD(track_details) AS td ( track_id INT, title TEXT, duration INT, added DATE
                                                                    , artists JSON, version TEXT, labels JSON
                                                                    , remixers JSON, releases JSON, keys JSON
-                                                                   , previews JSON, stores JSON, released DATE
-                                                                   , published DATE)
+                                                                   , genres JSON, previews JSON, stores JSON
+                                                                   , released DATE, published DATE)
                   NATURAL JOIN track__cart
                   NATURAL LEFT JOIN user__track)
        , tracks AS (SELECT JSON_AGG(td ORDER BY track__cart_added DESC) AS tracks

--- a/packages/front/src/Tracks.js
+++ b/packages/front/src/Tracks.js
@@ -8,23 +8,17 @@ import Track from './Track'
 import Spinner from './Spinner'
 import { Link, withRouter } from 'react-router-dom'
 import ToggleButton from './ToggleButton'
-import SearchBar from './SearchBar'
+import GlobalSearchBar from './GlobalSearchBar'
 import Popup from './Popup'
 import { isMobile } from 'react-device-detect'
+import { trackMatchesAllTerms } from './searchTerms'
+import { requestJSONwithCredentials } from './request-json-with-credentials'
 
-const filterMatches = (filter, { artists, title, keys, labels, releases }) => {
-  const trackDetailsString = [
-    ...artists.map(R.prop('name')),
-    title,
-    ...keys.map(R.prop('key')),
-    ...releases.map(R.prop('name')),
-    ...labels.map(R.prop('name')),
-  ]
-    .join(' ')
-    .toLowerCase()
+const trackPassesEnabledStores = (track, enabledStores) =>
+  enabledStores?.some((storeName) => track.stores?.find(R.propEq(storeName, 'name')))
 
-  return trackDetailsString.includes(filter)
-}
+const filterCartTracks = (tracks, terms, enabledStores) =>
+  tracks.filter((track) => trackPassesEnabledStores(track, enabledStores) && trackMatchesAllTerms(track, terms))
 
 class Tracks extends Component {
   constructor(props) {
@@ -37,9 +31,11 @@ class Tracks extends Component {
       createdNotifications: new Set(),
       modifyingNotification: false,
       cartFilter: '',
-      trackListFilter: '',
-      trackListFilterDebounced: '',
+      trackListFilterTerms: [],
+      trackListFilterInputValue: '',
+      trackListFilterEffectiveTerms: [],
       trackListFilterDebounce: undefined,
+      trackListFilterGenres: [],
       visibleStartIndex: 0,
       visibleEndIndex: 50,
       pullDistance: 0,
@@ -70,44 +66,24 @@ class Tracks extends Component {
   }
    */
 
+  getCartFilteredTracks() {
+    return this.props.listState === 'carts'
+      ? filterCartTracks(this.props.tracks, this.state.trackListFilterEffectiveTerms, this.props.enabledStores)
+      : this.props.tracks
+  }
+
   componentDidMount() {
     window.addEventListener('resize', this.handleResize)
-    
+
     if (this.tbodyRef.current) {
       const scrollTop = this.tbodyRef.current.scrollTop
       const clientHeight = this.tbodyRef.current.clientHeight
-      const tracks = this.props.listState === 'carts'
-        ? this.props.tracks.filter(
-            ({ artists, title, labels, keys, releases, stores }) =>
-              (!this.state.trackListFilterDebounced ||
-                filterMatches(this.state.trackListFilterDebounced, {
-                  artists,
-                  title,
-                  keys,
-                  labels,
-                  releases,
-                })) &&
-              this.props.enabledStores?.some((storeName) => stores.find(R.propEq(storeName, 'name'))),
-          )
-        : this.props.tracks
+      const tracks = this.getCartFilteredTracks()
       this.updateVisibleRange(scrollTop, clientHeight, tracks.length)
     }
-    
+
     setTimeout(() => {
-      const tracks = this.props.listState === 'carts'
-        ? this.props.tracks.filter(
-            ({ artists, title, labels, keys, releases, stores }) =>
-              (!this.state.trackListFilterDebounced ||
-                filterMatches(this.state.trackListFilterDebounced, {
-                  artists,
-                  title,
-                  keys,
-                  labels,
-                  releases,
-                })) &&
-              this.props.enabledStores?.some((storeName) => stores.find(R.propEq(storeName, 'name'))),
-          )
-        : this.props.tracks
+      const tracks = this.getCartFilteredTracks()
       this.measureTrackHeights(tracks)
       if (this.tbodyRef.current) {
         const scrollTop = this.tbodyRef.current.scrollTop
@@ -116,70 +92,34 @@ class Tracks extends Component {
       }
       this.tryAutoLoadMoreWithoutScroll(tracks.length)
     }, 0)
+
+    requestJSONwithCredentials({ path: '/genres' })
+      .then((genres) => this.setState({ trackListFilterGenres: genres || [] }))
+      .catch(() => {})
   }
 
   componentDidUpdate(prevProps, prevState) {
     if (
       prevProps.tracks !== this.props.tracks ||
       prevProps.listState !== this.props.listState ||
-      prevState.trackListFilterDebounced !== this.state.trackListFilterDebounced ||
+      prevState.trackListFilterEffectiveTerms !== this.state.trackListFilterEffectiveTerms ||
       prevProps.enabledStores !== this.props.enabledStores ||
       prevState.visibleStartIndex !== this.state.visibleStartIndex ||
       prevState.visibleEndIndex !== this.state.visibleEndIndex
     ) {
       setTimeout(() => {
-        const tracks = this.props.listState === 'carts'
-          ? this.props.tracks.filter(
-              ({ artists, title, labels, keys, releases, stores }) =>
-                (!this.state.trackListFilterDebounced ||
-                  filterMatches(this.state.trackListFilterDebounced, {
-                    artists,
-                    title,
-                    keys,
-                    labels,
-                    releases,
-                  })) &&
-                this.props.enabledStores?.some((storeName) => stores.find(R.propEq(storeName, 'name'))),
-            )
-          : this.props.tracks
+        const tracks = this.getCartFilteredTracks()
         this.measureTrackHeights(tracks)
         if (this.tbodyRef.current) {
           const scrollTop = this.tbodyRef.current.scrollTop
           const clientHeight = this.tbodyRef.current.clientHeight
-          const tracks = this.props.listState === 'carts'
-            ? this.props.tracks.filter(
-                ({ artists, title, labels, keys, releases, stores }) =>
-                  (!this.state.trackListFilterDebounced ||
-                    filterMatches(this.state.trackListFilterDebounced, {
-                      artists,
-                      title,
-                      keys,
-                      labels,
-                      releases,
-                    })) &&
-                  this.props.enabledStores?.some((storeName) => stores.find(R.propEq(storeName, 'name'))),
-              )
-            : this.props.tracks
           this.updateVisibleRange(scrollTop, clientHeight, tracks.length)
         }
         this.tryAutoLoadMoreWithoutScroll(tracks.length)
       }, 0)
     }
 
-    const tracks = this.props.listState === 'carts'
-      ? this.props.tracks.filter(
-          ({ artists, title, labels, keys, releases, stores }) =>
-            (!this.state.trackListFilterDebounced ||
-              filterMatches(this.state.trackListFilterDebounced, {
-                artists,
-                title,
-                keys,
-                labels,
-                releases,
-              })) &&
-            this.props.enabledStores?.some((storeName) => stores.find(R.propEq('name', storeName))),
-        )
-      : this.props.tracks
+    const tracks = this.getCartFilteredTracks()
     const tracksLengthChanged = prevProps.tracks.length !== this.props.tracks.length
     if (tracksLengthChanged || prevProps.loadingMore !== this.props.loadingMore || prevProps.hasMore !== this.props.hasMore) {
       this.tryAutoLoadMoreWithoutScroll(tracks.length)
@@ -299,42 +239,15 @@ class Tracks extends Component {
     if (this.resizeTimeout) {
       clearTimeout(this.resizeTimeout)
     }
-    
+
     this.resizeTimeout = setTimeout(() => {
       this.trackHeights.clear()
-      const tracks = this.props.listState === 'carts'
-        ? this.props.tracks.filter(
-            ({ artists, title, labels, keys, releases, stores }) =>
-              (!this.state.trackListFilterDebounced ||
-                filterMatches(this.state.trackListFilterDebounced, {
-                  artists,
-                  title,
-                  keys,
-                  labels,
-                  releases,
-                })) &&
-              this.props.enabledStores?.some((storeName) => stores.find(R.propEq(storeName, 'name'))),
-          )
-        : this.props.tracks
+      const tracks = this.getCartFilteredTracks()
       this.measureTrackHeights(tracks)
-      
+
       if (this.tbodyRef.current) {
         const scrollTop = this.tbodyRef.current.scrollTop
         const clientHeight = this.tbodyRef.current.clientHeight
-        const tracks = this.props.listState === 'carts'
-          ? this.props.tracks.filter(
-              ({ artists, title, labels, keys, releases, stores }) =>
-                (!this.state.trackListFilterDebounced ||
-                  filterMatches(this.state.trackListFilterDebounced, {
-                    artists,
-                    title,
-                    keys,
-                    labels,
-                    releases,
-                  })) &&
-                this.props.enabledStores?.some((storeName) => stores.find(R.propEq(storeName, 'name'))),
-            )
-          : this.props.tracks
         this.updateVisibleRange(scrollTop, clientHeight, tracks.length)
         this.tryAutoLoadMoreWithoutScroll(tracks.length)
       }
@@ -394,20 +307,7 @@ class Tracks extends Component {
     const scrollingDown = scrollTop > this.lastScrollTop
     this.lastScrollTop = scrollTop
 
-    const tracks = this.props.listState === 'carts'
-      ? this.props.tracks.filter(
-          ({ artists, title, labels, keys, releases, stores }) =>
-            (!this.state.trackListFilterDebounced ||
-              filterMatches(this.state.trackListFilterDebounced, {
-                artists,
-                title,
-                keys,
-                labels,
-                releases,
-              })) &&
-            this.props.enabledStores?.some((storeName) => stores.find(R.propEq(storeName, 'name'))),
-        )
-      : this.props.tracks
+    const tracks = this.getCartFilteredTracks()
 
     this.updateVisibleRange(scrollTop, clientHeight, tracks.length)
 
@@ -485,6 +385,67 @@ class Tracks extends Component {
 
   onCartFilterChange(filter) {
     this.setState({ cartFilter: filter })
+  }
+
+  computeEffectiveTrackListTerms(committedTerms, inputValue) {
+    const trimmed = (inputValue || '').trim()
+    const partial = trimmed ? [{ type: 'text', value: trimmed }] : []
+    return [...committedTerms, ...partial]
+  }
+
+  handleTrackListFilterChange(committedTerms, inputValue) {
+    if (this.state.trackListFilterDebounce) {
+      clearTimeout(this.state.trackListFilterDebounce)
+    }
+
+    const effectiveTerms = this.computeEffectiveTrackListTerms(committedTerms, inputValue)
+
+    if (effectiveTerms.length === 0) {
+      this.setState({
+        trackListFilterTerms: committedTerms,
+        trackListFilterInputValue: inputValue,
+        trackListFilterEffectiveTerms: [],
+        trackListFilterDebounce: undefined,
+      })
+      return
+    }
+
+    const timeout = setTimeout(() => {
+      this.setState({
+        trackListFilterEffectiveTerms: effectiveTerms,
+        trackListFilterDebounce: undefined,
+      })
+    }, 300)
+
+    this.setState({
+      trackListFilterTerms: committedTerms,
+      trackListFilterInputValue: inputValue,
+      trackListFilterDebounce: timeout,
+    })
+  }
+
+  handleTrackListFilterSearch(committedTerms, inputValue) {
+    if (this.state.trackListFilterDebounce) {
+      clearTimeout(this.state.trackListFilterDebounce)
+    }
+    this.setState({
+      trackListFilterTerms: committedTerms,
+      trackListFilterInputValue: inputValue,
+      trackListFilterEffectiveTerms: this.computeEffectiveTrackListTerms(committedTerms, inputValue),
+      trackListFilterDebounce: undefined,
+    })
+  }
+
+  handleTrackListFilterClear() {
+    if (this.state.trackListFilterDebounce) {
+      clearTimeout(this.state.trackListFilterDebounce)
+    }
+    this.setState({
+      trackListFilterTerms: [],
+      trackListFilterInputValue: '',
+      trackListFilterEffectiveTerms: [],
+      trackListFilterDebounce: undefined,
+    })
   }
 
   renderTracks(tracks) {
@@ -720,48 +681,16 @@ class Tracks extends Component {
                 >
                   {this.props.mode === 'app' ? (
                     <>
-                      <SearchBar
+                      <GlobalSearchBar
                         placeholder={'Filter'}
-                        value={this.state.trackListFilter}
-                        loading={this.state.trackListFilterDebounce}
+                        terms={this.state.trackListFilterTerms}
+                        loading={this.state.trackListFilterDebounce !== undefined}
                         className={'cart-filter'}
-                        style={{ maxWidth: '50ch' }}
                         styles={'large'}
-                        onChange={(_, filter) => {
-                          // TODO: replace aborted and debounce with flatmapLatest
-                          if (this.state.trackListFilterDebounce) {
-                            clearTimeout(this.state.trackListFilterDebounce)
-                            this.setState({ trackListFilterDebounce: undefined })
-                          }
-
-                          this.setState({ trackListFilter: filter })
-
-                          if (filter === '') {
-                            this.setState({ trackListFilterDebounce: undefined, trackListFilterDebounced: '' })
-                            clearTimeout(this.state.trackListFilterDebounce)
-                            return
-                          }
-
-                          const timeout = setTimeout(
-                            function (filter) {
-                              if (this.state.trackListFilter !== filter) {
-                                return
-                              }
-
-                              clearTimeout(this.state.trackListFilterDebounce)
-                              this.setState({ trackListFilterDebounce: undefined, trackListFilterDebounced: filter })
-                            }.bind(this, filter),
-                            500,
-                          )
-                          this.setState({ trackListFilterDebounce: timeout })
-                        }}
-                        onClearSearch={() => {
-                          this.setState({
-                            trackListFilter: '',
-                            trackListFilterDebounced: '',
-                            trackListFilterDebounce: undefined,
-                          })
-                        }}
+                        genres={this.state.trackListFilterGenres}
+                        onChange={this.handleTrackListFilterChange.bind(this)}
+                        onSearch={this.handleTrackListFilterSearch.bind(this)}
+                        onClearSearch={this.handleTrackListFilterClear.bind(this)}
                       />
                       <span className={'cart-details'}>
                         Tracks in cart: {this.props.selectedCart?.track_count}
@@ -955,17 +884,10 @@ class Tracks extends Component {
             {!this.props.fetchingCartDetails &&
               this.renderTracks(
                 this.props.listState === 'carts'
-                  ? tracks.filter(
-                      ({ artists, title, labels, keys, releases, stores }) =>
-                        (!this.state.trackListFilterDebounced ||
-                          filterMatches(this.state.trackListFilterDebounced, {
-                            artists,
-                            title,
-                            keys,
-                            labels,
-                            releases,
-                          })) &&
-                        this.props.enabledStores?.some((storeName) => stores.find(R.propEq(storeName, 'name'))),
+                  ? filterCartTracks(
+                      tracks,
+                      this.state.trackListFilterEffectiveTerms,
+                      this.props.enabledStores,
                     )
                   : tracks,
               )}

--- a/packages/front/src/searchTerms.js
+++ b/packages/front/src/searchTerms.js
@@ -216,3 +216,67 @@ export const applyEntityNamesFromUrlParam = (searchTerms, namesParam) => {
     return term
   })
 }
+
+const getTrackBpms = (track) => {
+  const raw = Array.isArray(track.bpms)
+    ? track.bpms
+    : Array.isArray(track.stores)
+      ? Array.from(new Set(track.stores.map((s) => s?.bpm)))
+      : []
+  return raw.filter((b) => b !== null && b !== undefined && !Number.isNaN(b)).map(Number)
+}
+
+const matchTrackText = (track, text) => {
+  const haystack = [
+    ...(track.artists || []).map((a) => a?.name),
+    track.title,
+    ...(track.keys || []).map((k) => k?.key),
+    ...(track.releases || []).map((r) => r?.name),
+    ...(track.labels || []).map((l) => l?.name),
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+  return haystack.includes(text.toLowerCase())
+}
+
+// Local (client-side) match used by the cart filter. The global search runs the
+// same term syntax server-side; this mirrors the behaviour against the tracks
+// already loaded in the browser. `key:~` falls back to exact match because the
+// chord-number compatibility data is not shipped to the client.
+export const trackMatchesTerm = (track, term) => {
+  switch (term.type) {
+    case 'text':
+      return matchTrackText(track, term.value)
+    case 'artist':
+      return (track.artists || []).some((a) => a?.id === term.id)
+    case 'label':
+      return (track.labels || []).some((l) => l?.id === term.id)
+    case 'release':
+      return (track.releases || []).some((r) => r?.id === term.id)
+    case 'track':
+      return track.id === term.id
+    case 'genre':
+      return (track.genres || []).some((g) => g?.id === term.id)
+    case 'bpm': {
+      const bpms = getTrackBpms(track)
+      if (term.min !== undefined) return bpms.some((b) => b >= term.min && b <= term.max)
+      if (term.fuzzy)
+        return bpms.some(
+          (b) => Math.min(Math.abs(b - term.bpm), Math.abs(b * 2 - term.bpm), Math.abs(b - term.bpm * 2)) < 5,
+        )
+      return bpms.some((b) => b === term.bpm)
+    }
+    case 'key': {
+      const keys = (track.keys || []).map((k) => (k?.key || '').toLowerCase())
+      return keys.includes(term.key.toLowerCase())
+    }
+    default:
+      return true
+  }
+}
+
+export const trackMatchesAllTerms = (track, terms) => {
+  if (!terms || terms.length === 0) return true
+  return terms.every((t) => trackMatchesTerm(track, t))
+}


### PR DESCRIPTION
## Summary
- The cart view's filter bar was wired with `onChange={(_, filter) => …}`, but `SearchBar` only passes the native event. `filter` was always `undefined`, the controlled value flipped to `undefined`, and only the debounce spinner showed while typed characters never appeared.
- Replace the plain `SearchBar` with the same `GlobalSearchBar` used in the top bar so the cart filter supports the same pill UI and the same syntax: `artist:`, `label:`, `release:`, `track:`, `genre:`, `bpm:` (exact / `~fuzzy` / `min-max`), `key:`, plus free-text and `"quoted phrases"`.
- New shared helper `trackMatchesAllTerms` in `searchTerms.js` applies the parsed terms client-side against the already-loaded cart tracks, mirroring the back-end search semantics. `key:~` falls back to exact match because the chord-number compatibility data is not shipped to the client.
- Tracks in cart responses now also include `genres` (added to the `JSON_TO_RECORD` destructure in `queryCartDetails`) so `genre:` filters resolve.

## Test plan
- [ ] Open a cart and type characters into the filter — characters appear, list filters as you type, spinner disappears once the debounce settles.
- [ ] Type `artist:<id>`, `label:<id>`, `release:<id>`, `track:<id>`, `genre:<id>` — terms become pills and only matching tracks remain.
- [ ] Try `bpm:128`, `bpm:~128`, `bpm:120-130` and `key:Am` — filtering matches the loaded tracks.
- [ ] Type a `"multi word"` quoted phrase and confirm it becomes a single text pill.
- [ ] Use Enter to commit immediately, Backspace on empty input to restore the last pill, and the clear button to reset.
- [ ] Verify the global top-bar search still works as before (no regression in `GlobalSearchBar`).

https://claude.ai/code/session_012WfKjFGsANagZnmW8CWqUT

---
_Generated by [Claude Code](https://claude.ai/code/session_012WfKjFGsANagZnmW8CWqUT)_