### PR TITLE
feat: PR preview video generation via Actions OIDC demo-test workflow

### DIFF
--- a/.github/workflows/pr-demo.yml
+++ b/.github/workflows/pr-demo.yml
@@ -21,12 +21,16 @@ jobs:
       - uses: actions/checkout@v4
 
       # ── 1. Determine the Railway PR preview URL ───────────────────────────
-      # Set RAILWAY_SERVICE_NAME and RAILWAY_PROJECT_NAME as repository
-      # variables (Settings → Variables → Actions).
+      # Railway publishes preview deployments at
+      # https://<service>-<environment>.up.railway.app, and our environments
+      # are named `fomoplayer-pr-<N>`. The service+environment names are
+      # already public on every preview URL, so they're hard-coded here
+      # instead of stored as repository variables.
       - name: Determine preview URL
         id: preview
         run: |
-          PREVIEW_URL="https://${{ vars.RAILWAY_SERVICE_NAME }}-${{ vars.RAILWAY_PROJECT_NAME }}-pr-${{ github.event.pull_request.number }}.up.railway.app"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PREVIEW_URL="https://fomoplayer-fomoplayer-pr-${PR_NUMBER}.up.railway.app"
           echo "url=${PREVIEW_URL}" >> "$GITHUB_OUTPUT"
 
       # ── 2. Wait for the Railway preview to be live ────────────────────────

--- a/.github/workflows/pr-demo.yml
+++ b/.github/workflows/pr-demo.yml
@@ -94,11 +94,12 @@ jobs:
       - name: Install Playwright browser
         run: yarn workspace fomoplayer_back npx playwright install --with-deps chromium
 
-      # ── 6. Run the browser test in demo mode (slow-mo, video, overlay) ────
+      # ── 6. Run the browser test in demo mode (slow-mo, video, trace) ──────
       - name: Run demo test
         env:
           PREVIEW_URL: ${{ steps.preview.outputs.url }}
           VIDEO_DIR: ${{ github.workspace }}/demo-output
+          TRACE_PATH: ${{ github.workspace }}/demo-output/trace.zip
           # OIDC_TOKEN is already in env from step 4
           # PW_SLOWMO defaults to 600ms when PREVIEW_URL is set (see setup.js)
         run: |
@@ -106,12 +107,12 @@ jobs:
           NODE_ENV=ci dotenv -e .env.ci -- \
             npx cascade-test "${{ steps.demo.outputs.test_file }}"
 
-      # ── 7. Upload the recorded video ──────────────────────────────────────
-      - name: Upload demo video
+      # ── 7. Upload the recorded video and trace ────────────────────────────
+      - name: Upload demo artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: demo-video-pr-${{ github.event.pull_request.number }}
+          name: demo-pr-${{ github.event.pull_request.number }}
           path: ${{ github.workspace }}/demo-output/
           retention-days: 30
 
@@ -124,6 +125,7 @@ jobs:
             const succeeded = '${{ job.status }}' === 'success'
             const icon = succeeded ? '✅' : '❌'
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            const artifactName = `demo-pr-${context.payload.pull_request.number}`
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -131,10 +133,12 @@ jobs:
               body: [
                 `${icon} **Demo test ${succeeded ? 'succeeded' : 'failed'}**`,
                 '',
-                `[View recording and run logs](${runUrl})`,
+                `[View run logs](${runUrl})`,
                 '',
                 succeeded
-                  ? 'Download the `demo-video-pr-${{ github.event.pull_request.number }}` artifact from the run page to watch the video.'
+                  ? `Download the \`${artifactName}\` artifact from the run page; it contains both the recorded video (\`*.webm\`) and a Playwright trace (\`trace.zip\`).`
                   : 'Check the run logs for details.',
+                '',
+                'Open the trace at [trace.playwright.dev](https://trace.playwright.dev/) — drag and drop `trace.zip` into the page (mouse pointer, network, console and DOM snapshots are all included).',
               ].join('\n'),
             })

--- a/.github/workflows/pr-demo.yml
+++ b/.github/workflows/pr-demo.yml
@@ -1,0 +1,140 @@
+name: PR Demo Test
+
+# Runs when a maintainer applies the 'demo-test' label, or when new commits are
+# pushed to a PR that already carries the label.
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+jobs:
+  demo-test:
+    if: contains(github.event.pull_request.labels.*.name, 'demo-test')
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Required to mint a GitHub Actions OIDC token for keyless login.
+      id-token: write
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── 1. Determine the Railway PR preview URL ───────────────────────────
+      # Set RAILWAY_SERVICE_NAME and RAILWAY_PROJECT_NAME as repository
+      # variables (Settings → Variables → Actions).
+      - name: Determine preview URL
+        id: preview
+        run: |
+          PREVIEW_URL="https://${{ vars.RAILWAY_SERVICE_NAME }}-${{ vars.RAILWAY_PROJECT_NAME }}-pr-${{ github.event.pull_request.number }}.up.railway.app"
+          echo "url=${PREVIEW_URL}" >> "$GITHUB_OUTPUT"
+
+      # ── 2. Wait for the Railway preview to be live ────────────────────────
+      - name: Wait for preview deployment
+        run: |
+          URL="${{ steps.preview.outputs.url }}"
+          echo "Polling ${URL}/api/health ..."
+          for i in $(seq 1 30); do
+            STATUS=$(curl -o /dev/null -s -w "%{http_code}" "${URL}/api/health" || echo 000)
+            if [ "$STATUS" = "200" ]; then echo "Ready (attempt ${i})"; exit 0; fi
+            echo "Attempt ${i}/30 — HTTP ${STATUS} — retrying in 10s"; sleep 10
+          done
+          echo "::error::Preview did not become ready within 5 minutes"; exit 1
+
+      # ── 3. Extract the test file path from the PR body ────────────────────
+      # The PR body must contain a fenced demo-test block with the path to a
+      # committed browser test relative to packages/back/, e.g.:
+      #
+      #   ```demo-test
+      #   test/browser/playback.js
+      #   ```
+      - name: Extract test file from PR body
+        id: demo
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body ?? ''
+            const match = body.match(/```demo-test\r?\n([\s\S]*?)```/)
+            if (!match) {
+              core.setFailed('No ```demo-test``` block found in PR body. Add one with a test file path.')
+              return
+            }
+            const testFile = match[1].trim()
+            if (!testFile.endsWith('.js') || testFile.includes('..')) {
+              core.setFailed(`Invalid test file path: "${testFile}"`)
+              return
+            }
+            console.log(`Running demo test: ${testFile}`)
+            core.setOutput('test_file', testFile)
+
+      # ── 4. Get a GitHub Actions OIDC token for keyless preview login ──────
+      # Audience is bound to this specific preview URL; the backend rejects
+      # tokens with a mismatched audience so tokens cannot be replayed across
+      # deployments. The token is masked in all subsequent log output.
+      - name: Get OIDC token
+        run: |
+          PREVIEW_URL="${{ steps.preview.outputs.url }}"
+          TOKEN=$(curl -s \
+            -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${PREVIEW_URL}" \
+            | jq -r .value)
+          echo "::add-mask::${TOKEN}"
+          echo "OIDC_TOKEN=${TOKEN}" >> "$GITHUB_ENV"
+
+      # ── 5. Set up Node and dependencies ───────────────────────────────────
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install Playwright browser
+        run: yarn workspace fomoplayer_back npx playwright install --with-deps chromium
+
+      # ── 6. Run the browser test in demo mode (slow-mo, video, overlay) ────
+      - name: Run demo test
+        env:
+          PREVIEW_URL: ${{ steps.preview.outputs.url }}
+          VIDEO_DIR: ${{ github.workspace }}/demo-output
+          # OIDC_TOKEN is already in env from step 4
+          # PW_SLOWMO defaults to 600ms when PREVIEW_URL is set (see setup.js)
+        run: |
+          cd packages/back
+          NODE_ENV=ci dotenv -e .env.ci -- \
+            npx cascade-test "${{ steps.demo.outputs.test_file }}"
+
+      # ── 7. Upload the recorded video ──────────────────────────────────────
+      - name: Upload demo video
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-video-pr-${{ github.event.pull_request.number }}
+          path: ${{ github.workspace }}/demo-output/
+          retention-days: 30
+
+      # ── 8. Comment on the PR ──────────────────────────────────────────────
+      - name: Comment on PR
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const succeeded = '${{ job.status }}' === 'success'
+            const icon = succeeded ? '✅' : '❌'
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: [
+                `${icon} **Demo test ${succeeded ? 'succeeded' : 'failed'}**`,
+                '',
+                `[View recording and run logs](${runUrl})`,
+                '',
+                succeeded
+                  ? 'Download the `demo-video-pr-${{ github.event.pull_request.number }}` artifact from the run page to watch the video.'
+                  : 'Check the run logs for details.',
+              ].join('\n'),
+            })

--- a/docs/auth/oidc-login-flow.md
+++ b/docs/auth/oidc-login-flow.md
@@ -1,0 +1,539 @@
+# OIDC Login Flow
+
+This document describes every login method available in Fomo Player: Google OIDC
+for browser sessions, the CLI PKCE flow for API key creation, the OIDC handoff
+flow for Railway PR-preview consumers, and the GitHub Actions OIDC login used by
+the automated PR demo-test bot.
+
+The authoritative source of truth is the code:
+
+- `packages/back/passport-setup.js` — Passport OpenID Connect strategy + verify
+  callback (account lookup/sign-up policy).
+- `packages/back/routes/auth.js` — All `/api/auth/...` routes (`/login/google`,
+  `/login/cli`, `/login/cli/google`, `/login/cli/confirm`, `/login/cli/deny`,
+  `/login/google/return`, `/login/google/handoff`, `/cli-token`,
+  `/api-keys/exchange-handoff`, `/login/actions`).
+- `packages/back/routes/shared/cli-auth-code.js` — In-memory PKCE
+  authorization code store (`issueCode` / `consumeCode`, 60 s TTL, S256
+  verification).
+- `packages/back/routes/shared/auth-handoff-token.js` — Handoff JWT mint /
+  verify (HS256, 60 s TTL).
+- `packages/back/routes/shared/auth-handoff-jti.js` +
+  `migrations/sqls/20260331110000-add-auth-handoff-jti-up.sql` — Replay
+  protection (one-time-use `jti` table).
+- `packages/back/routes/shared/safe-redirect.js` — `isSafeHandoffTarget`
+  validates that handoff target hostnames match Railway's PR-preview pattern.
+- `packages/back/routes/shared/github-actions-oidc.js` — GitHub Actions OIDC
+  JWT verification via JWKS (`verifyActionsToken`).
+- `packages/back/config.js` — Reads `OIDC_HANDOFF_URL`, `OIDC_HANDOFF_SECRET`,
+  `IS_PREVIEW_ENV`, `GITHUB_ACTIONS_OIDC_REPO`, etc.
+- `packages/cli/src/auth.js` — CLI loopback login + handoff exchange.
+- `packages/front/src/UserLogin.js` + `packages/front/src/App.js` — Browser
+  login link.
+
+> Stale references: `PREVIEW_DEPLOYMENT.md` describes an earlier JWKS / RS256
+> "internal handoff" model and a `/api/auth/handoff/exchange` endpoint that no
+> longer exists. The current implementation uses a single shared HS256 secret
+> (`OIDC_HANDOFF_SECRET`) and the routes documented below. The Chrome
+> extension still calls a `POST /api/auth/token/exchange-google` route that
+> is referenced from `packages/back/test/tests/users/auth/token-exchange.js`
+> but is not currently mounted in `routes/auth.js`; treat that flow as
+> not-implemented.
+
+---
+
+## Concepts
+
+### The login methods
+
+There are four distinct login paths:
+
+1. **Regular OIDC flow.** A browser performs the OIDC redirect dance directly
+   against the backend that talks to Google. On Google's callback the backend
+   creates an Express session via `req.login(user)` and redirects to the
+   frontend. This is the simple case and is what runs locally, in tests, in
+   production, and on the production "authority" backend itself.
+
+2. **Handoff flow.** Google only allows a fixed set of registered
+   `redirect_uri` values per OAuth client. PR-preview backends running on
+   dynamic Railway hostnames cannot each register their own redirect URI. So
+   one backend (the **authority**) owns the registered Google redirect URI
+   and performs the actual OIDC dance, then hands off the authenticated
+   identity to the **consumer** backend (preview or CLI loopback) by minting
+   a short-lived, single-use HMAC-signed token. The consumer verifies the
+   token and either logs the user in (browser preview) or creates an API
+   key (CLI).
+
+3. **CLI PKCE flow.** The CLI implements OAuth2 Authorization Code with PKCE
+   (RFC 7636). The backend serves a browser confirmation page; on approval it
+   issues an opaque single-use authorization code that the CLI exchanges (with
+   the `code_verifier`) for an API key. No browser redirect URI or Google
+   credential is needed beyond the initial browser login that establishes the
+   user session.
+
+4. **GitHub Actions OIDC login.** Only available on preview environments
+   (`IS_PREVIEW_ENV=true` + `GITHUB_ACTIONS_OIDC_REPO` configured). A GitHub
+   Actions workflow presents a short-lived JWT signed by GitHub to
+   `POST /api/auth/login/actions`. The backend verifies the JWT against
+   GitHub's JWKS, confirms the token is from the configured repository, and
+   establishes an Express session for a shared bot user. This is used
+   exclusively by the PR demo-test workflow — no shared secret is stored
+   anywhere.
+
+Both the regular OIDC flow and the handoff flow go through the same Passport
+OpenID Connect strategy and the same `/api/auth/login/google/return` callback
+handler — what differs is what the callback does with the authenticated user,
+and that branch is selected by the OIDC `state` parameter.
+
+### Handoff token format
+
+`packages/back/routes/shared/auth-handoff-token.js`. Used by the browser
+handoff flow (authority → preview consumer). Not used by the CLI flow.
+
+- **Claims:** `sub` = Google subject id, `oidcIssuer` = normalized OIDC issuer
+  (e.g. `accounts.google.com`), `iss`, `aud`, `jti` (random UUID), `iat`,
+  `exp`.
+- **Audience binding:** `iss` = authority origin, `aud` = consumer origin.
+- **Verification:** `verifyHandoffToken` — requires `sub`, `oidcIssuer`, `jti`,
+  `exp`.
+
+The TTL is `HANDOFF_TOKEN_TTL_SECONDS = 60` with 5 s clock tolerance. Replay
+protection: every accepted `jti` is inserted into `auth_handoff_jti` with
+`INSERT ... ON CONFLICT DO NOTHING`; a second use is rejected
+(`packages/back/routes/shared/auth-handoff-jti.js`).
+
+`POST /api-keys/exchange-handoff` verifies the token, consumes the `jti`,
+looks up the user by `(oidcIssuer, sub)`, and returns `{ key, id, name }`.
+
+### Configuration that picks the flow
+
+`packages/back/routes/auth.js` derives three values at startup from
+`packages/back/config.js`:
+
+```js
+const isSelfReferentialHandoffUrl = Boolean(
+  oidcHandoffAuthorityOrigin && apiOrigin && oidcHandoffAuthorityOrigin === apiOrigin,
+)
+const isHandoffConsumerConfigured = Boolean(
+  oidcHandoffUrl && oidcHandoffAuthorityOrigin && oidcHandoffSecret,
+)
+const canMintHandoff = Boolean(oidcHandoffSecret && apiOrigin)
+
+const shouldDelegateToAuthority = () => {
+  if (!isHandoffConsumerConfigured) return false
+  return !isSelfReferentialHandoffUrl
+}
+```
+
+| Value | True when | Meaning |
+|---|---|---|
+| `shouldDelegateToAuthority()` | `OIDC_HANDOFF_URL` is set, points to a different origin than this backend, **and** `OIDC_HANDOFF_SECRET` is set | This backend is a **consumer** — it will redirect `/login/google` to the authority and accept handoff at `/login/google/handoff` |
+| `isSelfReferentialHandoffUrl` | `OIDC_HANDOFF_URL` resolves to the same origin as `apiOrigin` | This backend is the **authority**; delegation is skipped (PR previews inherit this var, so it has to be detected at runtime) |
+| `canMintHandoff` | `OIDC_HANDOFF_SECRET` is set and `apiOrigin` is known | This backend can sign handoff tokens (required for both browser-handoff to consumer previews **and** for CLI login) |
+
+`isSafeHandoffTarget` (`packages/back/routes/shared/safe-redirect.js`) gates
+which target origins the authority will mint a handoff for. It enforces that
+the host matches the Railway PR-preview pattern
+`<RAILWAY_SERVICE_NAME>-<RAILWAY_PROJECT_NAME>-pr-<n>.up.railway.app` and is
+served over `https`.
+
+---
+
+## Browser login flow (web app)
+
+`packages/front/src/App.js` builds the link the user clicks:
+
+```js
+const googleLoginPath = `${config.apiURL}/auth/login/google?returnPath=${encodeURIComponent(buildLoginReturnPath())}`
+```
+
+### Regular flow (no delegation)
+
+```
+Browser ──GET /api/auth/login/google?returnPath=…──▶ Backend
+Backend ──302 to Google /o/oauth2/auth (state={returnPath})──▶ Browser
+Browser completes Google login
+Google ──GET /api/auth/login/google/return?code=…&state=…──▶ Backend
+Backend (passport verify): finds or creates account, applies sign-up policy
+Backend req.login(user) → sets session cookie
+Backend ──302 to ${frontendURL}${returnPath}──▶ Browser
+```
+
+Account lookup and sign-up policy live in
+`packages/back/passport-setup.js`. Sign-up is denied with
+`Sign up is not available` when `accountCount > MAX_ACCOUNT_COUNT` and no
+valid `inviteCode` is on the session; both denials end up redirecting to
+`${frontendURL}/?loginFailed=true` via `redirectWithLoginFailed`.
+
+### Handoff flow (preview consumer → authority)
+
+When the preview backend has `OIDC_HANDOFF_URL` (authority's
+`/api/auth/login/google`) and `OIDC_HANDOFF_SECRET` set:
+
+```
+1. Browser ──GET https://pr-N…/api/auth/login/google?returnPath=…──▶ Preview (consumer)
+2. Consumer (shouldDelegateToAuthority()=true)
+   ──302 to https://authority/api/auth/login/google
+       ?returnPath=…&handoffTarget=https://pr-N…──▶ Browser
+3. Browser ──GET /login/google?…&handoffTarget=…──▶ Authority
+4. Authority validates handoffTarget via isSafeHandoffTarget
+5. Authority ──passport.authenticate('openidconnect',
+       state={returnPath, handoffTarget})──▶ Google
+6. Google ──/api/auth/login/google/return──▶ Authority
+7. Authority verifies, looks up user (its own DB), mints handoff JWT:
+       iss = authorityOrigin, aud = handoffTarget origin,
+       sub = google sub, oidcIssuer = accounts.google.com
+8. Authority ──302 to ${handoffTarget}/api/auth/login/google/handoff
+       ?token=…&returnPath=…──▶ Browser
+9. Browser ──GET /api/auth/login/google/handoff?token=…──▶ Consumer
+10. Consumer verifies JWT (issuer=authority, audience=apiOrigin),
+    consumes jti (replay protection), looks up or creates account
+    in its own DB (consumer applies its own sign-up policy / invite-code
+    check), then req.login(user) → consumer session cookie
+11. Consumer ──302 to ${consumerFrontendURL}${returnPath}──▶ Browser
+```
+
+Important details:
+
+- The preview consumer must have its **own** `OIDC_HANDOFF_SECRET` matching
+  the authority's. The token is verified locally; no network call back to
+  the authority is made.
+- The preview consumer never talks to Google. Only the authority has a
+  Google OAuth client and a registered redirect URI.
+- Sign-up policy runs on the consumer (it has the consumer's user table) —
+  the authority's user record is irrelevant here. The consumer's
+  `req.session.inviteCode` is consulted just like in the regular flow.
+- Cross-site session cookies. When `IS_PREVIEW_ENV=true`,
+  `packages/back/index.js` sets `cookie.secure=true` and
+  `cookie.sameSite='none'` so the session cookie set in step 10 survives
+  the cross-origin redirect.
+
+---
+
+## CLI login flow (`fomoplayer login`)
+
+The CLI implements **OAuth2 Authorization Code with PKCE** (RFC 7636), the
+same pattern used by first-party CLI tools such as GitHub CLI and Stripe CLI.
+This prevents the long-lived API key from ever appearing in the browser URL
+bar or history.
+
+`packages/cli/src/auth.js` always:
+1. Generates a random `codeVerifier` (32 cryptographic bytes, base64url),
+   derives `codeChallenge = base64url(SHA256(codeVerifier))`, and a random
+   `state` (16 bytes, base64url).
+2. Binds a random port `P` on `127.0.0.1`.
+3. Opens
+   `${apiUrl}/api/auth/login/cli?callbackPort=P&code_challenge=…&code_challenge_method=S256&state=…`
+   in the browser.
+4. Waits up to 120 s for a `?code=…&state=…` GET to arrive on that port.
+5. Verifies the returned `state` matches what was sent (CSRF protection).
+6. POSTs `{ code, code_verifier }` to `POST /api/auth/cli-token`.
+7. Responds to the browser with a styled "Login successful" HTML page.
+8. Stores the returned `fp_<uuid>` API key in `~/.fomoplayer/config.json`.
+
+What happens in steps 3–6 depends on whether the user already has a browser
+session.
+
+### Path A — user already logged in to the web app
+
+```
+1. CLI opens browser to
+   ${apiUrl}/api/auth/login/cli?callbackPort=P&code_challenge=C&code_challenge_method=S256&state=S
+2. GET /login/cli (user has session):
+   backend stores P, C, S in session,
+   serves HTML page: "Grant CLI access?" with Allow / Deny buttons
+3a. User clicks Allow →
+    POST /login/cli/confirm (session carries P, C, S)
+    backend calls issueCode(userId, C) → opaque 60 s auth code
+    302 to http://localhost:P/?code=<code>&state=S
+3b. User clicks Deny →
+    POST /login/cli/deny
+    backend serves "Access denied. You can close this tab." page
+    (CLI times out after 120 s)
+4. (Allow path) CLI loopback receives ?code=&state=,
+   verifies state === S,
+   POSTs { code, code_verifier } to POST /api/auth/cli-token:
+     backend calls consumeCode(code, codeVerifier):
+       verifies base64url(SHA256(codeVerifier)) === stored codeChallenge
+       deletes code (single-use), checks 60 s TTL
+       creates fp_<uuid>, stores SHA-256 hash in api_key table
+       returns { access_token: "fp_<uuid>", token_type: "bearer" }
+   CLI stores the API key; all subsequent requests use
+   Authorization: Bearer fp_<uuid>
+```
+
+### Path B — user not yet logged in
+
+```
+1. CLI opens browser to
+   ${apiUrl}/api/auth/login/cli?callbackPort=P&code_challenge=C&code_challenge_method=S256&state=S
+2. GET /login/cli (no session):
+   backend stores P, C, S in session,
+   serves HTML page: "Fomo Player CLI Access" with "Log in with Google" button
+3. User clicks "Log in with Google" →
+   GET /login/cli/google?callbackPort=P
+   passport.authenticate('openidconnect',
+     state = { returnToCli: true, cliCallbackPort: P })
+4. Browser → Google OIDC dance → GET /login/google/return
+5. Return handler (returnToCli branch):
+   req.login(user) — establishes browser session
+   302 to /api/auth/login/cli?callbackPort=P
+   (session already carries C and S from step 2)
+6. GET /login/cli (user now has session) → same as Path A step 2 onward
+```
+
+### Notable properties
+
+- The CLI never sees user credentials or the OIDC ID/access token.
+- The `fp_<uuid>` API key **never appears in a browser URL or redirect**. The
+  browser only ever sees an opaque, single-use authorization code.
+- The API key is created only after the user explicitly approves on the
+  browser confirmation page and only after the CLI presents the correct
+  `code_verifier`. Denial delivers no key; the CLI times out cleanly after 120 s.
+- `codeVerifier` never leaves the CLI process. An attacker who intercepts the
+  `?code=&state=` redirect cannot exchange the code without it.
+- There is no auto sign-up. The user must already have an account (established
+  via the web app login) before confirming CLI access.
+
+---
+
+## GitHub Actions OIDC login (PR demo-test bot)
+
+Only available on Railway PR-preview environments when `IS_PREVIEW_ENV=true`
+**and** `GITHUB_ACTIONS_OIDC_REPO` is set.
+
+This flow lets an automated GitHub Actions workflow log in to a preview backend
+without any shared secret. It relies on GitHub's built-in OIDC token service:
+each workflow run can request a short-lived, RS256-signed JWT that
+cryptographically proves which repository and workflow minted it.
+
+### How it works
+
+```
+1. GitHub Actions workflow (pr-demo.yml) requests an OIDC token from
+   GitHub's token service via the Actions token API (curl with
+   ACTIONS_ID_TOKEN_REQUEST_TOKEN), with audience = PREVIEW_URL.
+
+2. Workflow calls:
+   POST ${PREVIEW_URL}/api/auth/login/actions
+   { "token": "<GitHub OIDC JWT>" }
+
+3. Backend (preview consumer, isPreviewEnv=true):
+   a. Fetches GitHub's JWKS from
+      https://token.actions.githubusercontent.com/.well-known/jwks.json
+      (cached via jwks-rsa)
+   b. Verifies JWT signature (RS256), issuer, expiry
+   c. Checks aud === apiOrigin  (prevents token reuse on a different preview)
+   d. Checks repository claim === GITHUB_ACTIONS_OIDC_REPO
+      (prevents tokens from forks or unrelated repos)
+   e. Calls account.findOrCreateByIdentifier(
+        'token.actions.githubusercontent.com',
+        githubActionsOidcRepo
+      ) → shared bot user (created on first login, reused thereafter)
+   f. req.login(user) → Express session cookie
+
+4. Workflow uses Playwright's page.request.post() for step 2 so the
+   Set-Cookie response is automatically stored in the browser context's
+   cookie jar. Subsequent page.goto() calls carry the session cookie.
+
+5. Playwright runs the demo steps from the PR body with video recording.
+```
+
+### Security properties
+
+- **No shared secret.** The JWT is signed by GitHub's private key and verified
+  against their public JWKS. There is nothing to leak.
+- **Audience binding.** Each Railway PR preview has a unique hostname. The
+  `aud` claim is set to `PREVIEW_URL` in the workflow and validated against
+  `apiOrigin` on the backend. A token minted for `pr-5` cannot be replayed
+  against `pr-6`.
+- **Repository binding.** The `repository` claim is checked against
+  `GITHUB_ACTIONS_OIDC_REPO`. Tokens from forks or other repositories are
+  rejected.
+- **Production never exposes this endpoint.** The route is registered only
+  when `IS_PREVIEW_ENV=true`. Production deployments never set this variable.
+- **Bot user is isolated.** The bot user is identified by issuer
+  `token.actions.githubusercontent.com` and subject = the repo name. It
+  shares no credentials with human users and cannot access production.
+
+### Playwright session establishment
+
+`page.request` in Playwright shares the same cookie jar as the browser
+context. Cookies set by the `POST /api/auth/login/actions` response are
+automatically available to all subsequent `page.goto()` navigations:
+
+```js
+// Login: cookie stored automatically in context
+const loginRes = await page.request.post(`${PREVIEW_URL}/api/auth/login/actions`, {
+  data: { token: oidcToken },
+})
+// All subsequent navigations carry the session cookie
+await page.goto('/tracks/recent')
+```
+
+### Demo mode (slowMo + video + visual overlay)
+
+When `PREVIEW_URL` is set, `test/lib/setup.js` automatically enables:
+- **slowMo** — defaults to 600 ms per action (override with `PW_SLOWMO`),
+  making every interaction visible to a human reviewer.
+- **Video recording** — written to `VIDEO_DIR` when set; finalized when the
+  browser context closes (wired to `process.beforeExit`).
+- **Visual overlay** — injected into every page via `context.addInitScript()`:
+  an orange cursor indicator, click ripple effects, a keyboard badge showing
+  currently-held keys, and a scroll-direction arrow.
+
+### Test seeding in remote mode
+
+The existing browser tests seed fixture tracks via direct DB access locally.
+In remote mode (`PREVIEW_URL` set), `test/lib/seed.js` instead POSTs the
+same transformed fixture data to the existing `POST /api/me/tracks` endpoint
+(the same path the Chrome extension uses), so the bot user's track list is
+populated before assertions run. `test/lib/test-user.js` fetches the bot
+user's ID from `GET /api/auth/me`.
+
+---
+
+## Per-environment configuration
+
+These are the environment variables that determine which flows are available:
+
+- `OIDC_HANDOFF_URL` — if set and points to a different origin than this
+  backend, this backend acts as a **consumer**.
+- `OIDC_HANDOFF_SECRET` — required to mint or verify handoff tokens. Must be
+  identical on authority and all consumers (and on the same backend that
+  exposes the CLI exchange endpoint).
+- `GOOGLE_OIDC_CLIENT_ID` / `GOOGLE_OIDC_CLIENT_SECRET` /
+  `GOOGLE_OIDC_API_REDIRECT` — only required on the backend that actually
+  talks to Google (the authority).
+- `IS_PREVIEW_ENV=true` — toggles `secure`/`SameSite=none` session cookies
+  and enables the GitHub Actions OIDC login endpoint.
+- `GITHUB_ACTIONS_OIDC_REPO` — the `owner/repo` string that GitHub Actions
+  OIDC tokens must claim. Required alongside `IS_PREVIEW_ENV=true` for the
+  bot login endpoint to be registered.
+- `RAILWAY_SERVICE_NAME` + `RAILWAY_PROJECT_NAME` — read by
+  `isSafeHandoffTarget` to validate consumer hostnames.
+
+### Local development (`NODE_ENV=development`)
+
+Defaults from `packages/back/.env.development`:
+
+```
+GOOGLE_OIDC_CLIENT_ID=foo
+GOOGLE_OIDC_CLIENT_SECRET=bar
+GOOGLE_OIDC_API_REDIRECT=
+OIDC_HANDOFF_URL=
+OIDC_HANDOFF_SECRET=
+IS_PREVIEW_ENV=
+GOOGLE_OIDC_MOCK=
+GITHUB_ACTIONS_OIDC_REPO=
+```
+
+- `shouldDelegateToAuthority()` = false, `canMintHandoff` = false (no secret).
+- **Browser login: regular OIDC flow** against Google directly.
+- **CLI login:** works out of the box. No `OIDC_HANDOFF_SECRET` is required.
+- **Bot login:** not available (`IS_PREVIEW_ENV` not set).
+- Session cookie: `secure=false`, `SameSite=lax`.
+
+### Tests (`NODE_ENV=test`, `packages/back/.env.test`)
+
+```
+GOOGLE_OIDC_MOCK=true
+OIDC_HANDOFF_URL=
+OIDC_HANDOFF_SECRET=test-handoff-secret
+IS_PREVIEW_ENV=
+GITHUB_ACTIONS_OIDC_REPO=
+```
+
+- `shouldDelegateToAuthority()` = false → tests exercise the **regular flow**
+  when hitting `/login/google` and the **PKCE CLI flow** when hitting
+  `/login/cli` / `/login/cli/confirm` / `/cli-token`.
+- The browser-side handoff path (consumer → authority) is exercised in
+  isolation by unit/integration tests rather than by end-to-end runs (see
+  `packages/back/test/tests/users/auth/handoff-token.js`,
+  `handoff-login-signup-policy.js`, `handoff-invite-codes.js`).
+- The GitHub Actions OIDC endpoint is tested with mocked `verifyActionsToken`
+  in `packages/back/test/tests/users/auth/actions-oidc-login.js`.
+
+CI (`packages/back/.env.ci`) is the same shape.
+
+### Railway PR previews
+
+Two roles, same codebase, different env values:
+
+#### Authority (the "main" Railway environment that owns the Google client)
+
+- `GOOGLE_OIDC_CLIENT_ID` / `GOOGLE_OIDC_CLIENT_SECRET` set.
+- `GOOGLE_OIDC_API_REDIRECT=https://<authority-host>/api/auth/login/google/return`
+  (registered in Google).
+- `OIDC_HANDOFF_SECRET` set.
+- `OIDC_HANDOFF_URL` may either be unset or point to the authority itself —
+  if it points to the authority's own origin, `isSelfReferentialHandoffUrl`
+  is `true` and delegation is skipped.
+- `IS_PREVIEW_ENV=true` so session cookies are cross-site.
+- `RAILWAY_SERVICE_NAME` / `RAILWAY_PROJECT_NAME` populated by Railway.
+- `GITHUB_ACTIONS_OIDC_REPO` — set if bot login is needed on the authority
+  (typically not required; bot targets individual PR preview consumers).
+- **Flows used:**
+  - Browser login arriving directly at the authority: regular OIDC flow.
+  - Browser login from a consumer preview: **handoff flow**.
+  - CLI login pointed at the authority: **CLI PKCE flow** ending in an API key.
+
+#### Consumer (PR-preview backend on `…-pr-<N>.up.railway.app`)
+
+- `OIDC_HANDOFF_URL=https://<authority-host>/api/auth/login/google`.
+- `OIDC_HANDOFF_SECRET` matches the authority.
+- `apiOrigin` differs from `oidcHandoffAuthorityOrigin` →
+  `shouldDelegateToAuthority()` = true.
+- No Google OIDC client credentials needed.
+- `IS_PREVIEW_ENV=true`.
+- `RAILWAY_SERVICE_NAME` / `RAILWAY_PROJECT_NAME` populated.
+- `GITHUB_ACTIONS_OIDC_REPO=<owner>/<repo>` — enables the bot login endpoint.
+- **Flows used:**
+  - Browser login: **handoff flow** (consumer → authority → consumer).
+  - CLI login: should be pointed at the authority, not a preview consumer.
+  - Bot login: **GitHub Actions OIDC** via `POST /api/auth/login/actions`.
+
+### Production
+
+- Single backend acting as the authority.
+- `GOOGLE_OIDC_CLIENT_ID` / `GOOGLE_OIDC_CLIENT_SECRET` /
+  `GOOGLE_OIDC_API_REDIRECT` set.
+- `OIDC_HANDOFF_SECRET` set.
+- `IS_PREVIEW_ENV` empty → `SameSite=lax`, no bot login endpoint.
+- `GITHUB_ACTIONS_OIDC_REPO` **not set** — bot login endpoint is never mounted.
+- **Browser login:** regular OIDC flow.
+- **CLI login:** CLI PKCE flow ending in an API key.
+
+---
+
+## Summary table — which flow per environment
+
+| Environment | Backend role | Browser login | CLI login | Bot login |
+|---|---|---|---|---|
+| Local dev (`NODE_ENV=development`) | Authority (talks to Google) | Regular OIDC | PKCE CLI flow | Not available |
+| Test / CI (`NODE_ENV=test`) | Authority (Google mocked) | Regular OIDC against the mock | PKCE CLI flow | Not available |
+| Railway preview — authority | Authority | Regular OIDC; also issues handoffs to consumer previews | PKCE CLI flow | Not available (unless `GITHUB_ACTIONS_OIDC_REPO` set) |
+| Railway preview — consumer (`…-pr-N…`) | Consumer | Handoff flow via authority | Not the recommended target for CLI | **GitHub Actions OIDC** (`IS_PREVIEW_ENV` + `GITHUB_ACTIONS_OIDC_REPO`) |
+| Production | Authority | Regular OIDC | CLI PKCE flow | Not available |
+
+---
+
+## When is the handoff flow needed?
+
+The handoff flow is required precisely when the backend serving the user
+cannot itself complete the Google OIDC dance — in this codebase that means
+**Railway PR-preview consumer backends running on dynamic hostnames that
+aren't registered as Google redirect URIs**.
+
+The CLI flow is unrelated to the handoff machinery. The CLI uses OAuth2
+Authorization Code with PKCE: the backend serves a browser confirmation page,
+issues an opaque auth code on approval, and the CLI exchanges it (with the
+`code_verifier`) for an API key via `POST /api/auth/cli-token`. The API key
+never appears in a browser URL. If the user is not yet logged in, the
+confirmation page offers a "Log in with Google" button that completes the
+regular OIDC dance and returns to the confirmation page — after which the same
+PKCE exchange runs.
+
+The GitHub Actions OIDC login is unrelated to both flows above. It is purely
+for automated E2E testing on PR preview deployments and is never available on
+production.

--- a/docs/auth/oidc-login-flow.md
+++ b/docs/auth/oidc-login-flow.md
@@ -371,16 +371,17 @@ const loginRes = await page.request.post(`${PREVIEW_URL}/api/auth/login/actions`
 await page.goto('/tracks/recent')
 ```
 
-### Demo mode (slowMo + video + visual overlay)
+### Demo mode (slowMo + video + trace)
 
 When `PREVIEW_URL` is set, `test/lib/setup.js` automatically enables:
 - **slowMo** — defaults to 600 ms per action (override with `PW_SLOWMO`),
   making every interaction visible to a human reviewer.
 - **Video recording** — written to `VIDEO_DIR` when set; finalized when the
   browser context closes (wired to `process.beforeExit`).
-- **Visual overlay** — injected into every page via `context.addInitScript()`:
-  an orange cursor indicator, click ripple effects, a keyboard badge showing
-  currently-held keys, and a scroll-direction arrow.
+- **Playwright trace** — written to `TRACE_PATH` when set, with screenshots,
+  DOM snapshots, and sources enabled. The trace.zip can be opened at
+  [trace.playwright.dev](https://trace.playwright.dev/) (drag-and-drop) for
+  cursor pointer, click highlights, network, console, and full DOM scrubbing.
 
 ### Test seeding in remote mode
 

--- a/packages/back/config.js
+++ b/packages/back/config.js
@@ -48,4 +48,5 @@ module.exports = {
   oidcHandoffUrl,
   oidcHandoffAuthorityOrigin,
   oidcHandoffSecret: process.env.OIDC_HANDOFF_SECRET || undefined,
+  githubActionsOidcRepo: process.env.GITHUB_ACTIONS_OIDC_REPO || undefined,
 }

--- a/packages/back/routes/auth.js
+++ b/packages/back/routes/auth.js
@@ -12,6 +12,7 @@ const { upsertUserAuthorizationTokens } = require('./db')
 const { isSafeRedirectPath, isSafeHandoffTarget } = require('./shared/safe-redirect')
 const { mintHandoffToken: defaultMintHandoffToken, verifyHandoffToken: defaultVerifyHandoffToken } = require('./shared/auth-handoff-token')
 const { issueCode: defaultIssueCode, consumeCode: defaultConsumeCode } = require('./shared/cli-auth-code')
+const { verifyActionsToken: defaultVerifyActionsToken, GITHUB_ACTIONS_ISSUER } = require('./shared/github-actions-oidc')
 const { evaluateSignUpPolicy, getRequestOrigin } = require('./shared/auth-flow')
 const logger = require('fomoplayer_shared').logger(__filename)
 
@@ -25,6 +26,7 @@ const createAuthRouter = ({
   verifyHandoffTokenFn = defaultVerifyHandoffToken,
   issueCodeFn = defaultIssueCode,
   consumeCodeFn = defaultConsumeCode,
+  verifyActionsTokenFn = defaultVerifyActionsToken,
 } = {}) => {
   const router = express.Router()
   const {
@@ -37,6 +39,7 @@ const createAuthRouter = ({
     oidcHandoffAuthorityOrigin,
     isPreviewEnv,
     maxAccountCount,
+    githubActionsOidcRepo,
   } = config
 
   const loginFailedUrl = `${frontendURL}/?loginFailed=true`
@@ -399,6 +402,11 @@ const createAuthRouter = ({
     } catch (e) { next(e) }
   })
 
+  router.get('/me', (req, res) => {
+    if (!req.isAuthenticated()) return res.status(401).end()
+    return res.json({ id: req.user.id })
+  })
+
   router.get('/spotify', async ({ user: { id: userId }, query }, res) => {
     const authorizationUrl = getAuthorizationUrl(query.path, query.write === 'true')
     res.redirect(authorizationUrl)
@@ -423,6 +431,36 @@ const createAuthRouter = ({
     const safePath = isSafeRedirectPath(path, frontendURL) ? path : ''
     res.redirect(`${frontendURL}${safePath}`)
   })
+
+  if (isPreviewEnv && githubActionsOidcRepo) {
+    router.post('/login/actions', async (req, res, next) => {
+      try {
+        const { token } = req.body ?? {}
+        if (!token) return res.status(400).json({ error: 'token is required' })
+
+        const payload = await verifyActionsTokenFn({
+          token,
+          audience: apiOrigin,
+          allowedRepo: githubActionsOidcRepo,
+        })
+        if (!payload) {
+          logger.warn('Actions OIDC login rejected: invalid or unauthorized token')
+          return res.status(401).json({ error: 'Invalid or unauthorized Actions token' })
+        }
+
+        const normalizedIssuer = GITHUB_ACTIONS_ISSUER.replace(/^https?:\/\//, '')
+        const user = await account.findOrCreateByIdentifier(normalizedIssuer, githubActionsOidcRepo)
+        if (!user) return res.status(500).json({ error: 'Failed to resolve bot user' })
+
+        req.login(user, (err) => {
+          if (err) return next(err)
+          res.status(204).end()
+        })
+      } catch (e) {
+        next(e)
+      }
+    })
+  }
 
   if (process.env.NODE_ENV !== 'production') {
     router.post(

--- a/packages/back/routes/public.js
+++ b/packages/back/routes/public.js
@@ -45,6 +45,8 @@ const createPublicRouter = ({
     }
   })
 
+  router.get('/health', (_, res) => res.json({ status: 'ok' }))
+
   router.get('/sign-up-available', async (_, res) => {
     if (config.isPreviewEnv) {
       return res.send({ available: false })

--- a/packages/back/routes/shared/github-actions-oidc.js
+++ b/packages/back/routes/shared/github-actions-oidc.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const jwksRsa = require('jwks-rsa')
+const jwt = require('jsonwebtoken')
+
+const GITHUB_ACTIONS_ISSUER = 'https://token.actions.githubusercontent.com'
+
+const jwksClient = jwksRsa({
+  cache: true,
+  rateLimit: true,
+  jwksRequestsPerMinute: 5,
+  jwksUri: `${GITHUB_ACTIONS_ISSUER}/.well-known/jwks.json`,
+})
+
+const getSigningKey = (header, callback) => {
+  jwksClient.getSigningKey(header.kid, (err, key) => {
+    if (err) return callback(err)
+    callback(null, key.getPublicKey())
+  })
+}
+
+const verifyActionsToken = ({ token, audience, allowedRepo }) =>
+  new Promise((resolve) => {
+    if (!token || !audience || !allowedRepo) return resolve(null)
+    jwt.verify(
+      token,
+      getSigningKey,
+      { issuer: GITHUB_ACTIONS_ISSUER, audience, algorithms: ['RS256'] },
+      (err, payload) => {
+        if (err || !payload || typeof payload !== 'object') return resolve(null)
+        if (payload.repository !== allowedRepo) return resolve(null)
+        resolve(payload)
+      },
+    )
+  })
+
+module.exports = { verifyActionsToken, GITHUB_ACTIONS_ISSUER }

--- a/packages/back/test/browser/demo.js
+++ b/packages/back/test/browser/demo.js
@@ -1,0 +1,115 @@
+// Demo walkthrough used by .github/workflows/pr-demo.yml. Runs against the
+// Railway PR preview with slow-mo, video, and Playwright tracing enabled, so
+// the recorded artifacts read as a guided tour rather than an assertion log.
+// Asserts only the milestones that prove each step actually happened — anything
+// finer-grained belongs in the dedicated browser tests next door.
+
+const { expect } = require('chai')
+const { test } = require('cascade-test')
+const { getSharedContext, dismissOnboarding, waitForWithTimeoutMessage } = require('../lib/setup')
+const { seedTracks } = require('../lib/seed')
+const { resolveTestUserId } = require('../lib/test-user')
+
+const cartButton = (page) => page.locator('.preview_actions_wrapper .button-drop_down-left').first()
+const playButton = (page) => page.locator('.button-playback').first()
+const pauseIcon = (page) => page.locator('.button-playback svg[data-icon="pause"]').first()
+const playIcon = (page) => page.locator('.button-playback svg[data-icon="play"]').first()
+
+test({
+  setup: async () => {
+    const { page } = await getSharedContext()
+    const userId = await resolveTestUserId()
+    await seedTracks({ userIds: [userId] })
+    await page.goto('/tracks/recent')
+    await waitForWithTimeoutMessage(
+      () => page.waitForSelector('.tracks-table', { timeout: 15000 }),
+      'Load the tracks table before starting the demo walkthrough.',
+    )
+    await dismissOnboarding(page)
+    return { page, timeout: 60000 }
+  },
+
+  'walkthrough: select, play, pause, add to cart, open cart': async ({ page }) => {
+    await page.goto('/tracks/recent')
+    await waitForWithTimeoutMessage(
+      () => page.waitForSelector('.tracks-table', { timeout: 15000 }),
+      'Land on the recent tracks page for the demo walkthrough.',
+    )
+
+    const targetTrack = page.locator('.track').nth(1)
+    await targetTrack.click()
+    await waitForWithTimeoutMessage(
+      () =>
+        page.waitForFunction(
+          () => document.querySelectorAll('.track')[1]?.classList.contains('selected'),
+          { timeout: 10000 },
+        ),
+      'Wait for the chosen track to enter the selected state.',
+    )
+    const selectedTitle = (await targetTrack.locator('.title-cell').first().innerText()).trim()
+    expect(selectedTitle.length).to.be.greaterThan(0)
+
+    await playButton(page).click()
+    await waitForWithTimeoutMessage(
+      () => pauseIcon(page).waitFor({ timeout: 10000 }),
+      'Wait for playback to start (pause icon appears once audio is playing).',
+    )
+
+    await playButton(page).click()
+    await waitForWithTimeoutMessage(
+      () => playIcon(page).waitFor({ timeout: 10000 }),
+      'Wait for playback to pause (play icon returns).',
+    )
+
+    const cartTitleBefore = (await cartButton(page).getAttribute('title')) || ''
+    if (cartTitleBefore.toLowerCase().includes('remove')) {
+      await cartButton(page).click()
+      await waitForWithTimeoutMessage(
+        () =>
+          page.waitForFunction(
+            () =>
+              document
+                .querySelector('.preview_actions_wrapper .button-drop_down-left')
+                ?.getAttribute('title')
+                ?.toLowerCase()
+                .includes('add to default cart'),
+            { timeout: 10000 },
+          ),
+        'Reset cart membership so the demo always exercises the add path.',
+      )
+    }
+
+    await cartButton(page).click()
+    await waitForWithTimeoutMessage(
+      () =>
+        page.waitForFunction(
+          () =>
+            document
+              .querySelector('.preview_actions_wrapper .button-drop_down-left')
+              ?.getAttribute('title')
+              ?.toLowerCase()
+              .includes('remove from default cart'),
+          { timeout: 10000 },
+        ),
+      'Wait for the cart button to flip to the "remove" state, confirming the add succeeded.',
+    )
+
+    const cartsNavButton = page.locator('.menu_left a, .menu_left button').filter({ hasText: 'Carts' }).first()
+    await cartsNavButton.click()
+    await waitForWithTimeoutMessage(
+      () => page.waitForURL(/\/carts\/[^/]+/, { timeout: 10000 }),
+      'Navigate to the default cart route.',
+    )
+    await waitForWithTimeoutMessage(
+      () =>
+        page.waitForFunction(
+          () => document.querySelector('.cart-details')?.textContent?.includes('Tracks in cart:'),
+          { timeout: 10000 },
+        ),
+      'Wait for the cart details header to render.',
+    )
+
+    const cartTitles = (await page.locator('.track .title-cell').allInnerTexts()).map((t) => t.trim())
+    expect(cartTitles).to.include(selectedTitle)
+  },
+})

--- a/packages/back/test/lib/seed.js
+++ b/packages/back/test/lib/seed.js
@@ -1,11 +1,14 @@
 const { setupBeatportTracks } = require('./tracks')
+const { getBrowserContext } = require('./setup')
+const { beatportTracksTransform } = require('../../../chrome-extension/src/js/transforms/beatport')
+const { storeUrl: beatportUrl } = require('../../routes/stores/beatport/logic')
+
 const firstTrack = require('../fixtures/noisia_concussion_beatport.json')
 const secondTrack = require('../fixtures/noisia_purpose_beatport.json')
 const thirdTrack = require('../fixtures/noisia_purpose_remix_beatport.json')
 const fourthTrack = require('../fixtures/beatport_operator_track_pageprops.json')
 const fifthTrack = require('../fixtures/beatport_dub_power_track_pageprops.json')
 const sixthTrack = require('../fixtures/noisia_block_control_beatport.json')
-const { beatportTracksTransform } = require('../../../chrome-extension/src/js/transforms/beatport')
 
 const seedFixtures = [firstTrack, secondTrack, thirdTrack, fourthTrack, fifthTrack, sixthTrack]
 const transformedSeedTracks = seedFixtures.flatMap((fixture) => beatportTracksTransform(fixture))
@@ -22,7 +25,22 @@ const seededTrackArtists = Array.from(
   ),
 )
 
+const isRemotePreview = Boolean(process.env.PREVIEW_URL)
+
 module.exports.seedTracks = async ({ userIds }) => {
+  if (isRemotePreview) {
+    // In remote preview mode the bot user is the only test user; we seed via
+    // the existing POST /api/me/tracks endpoint (same path as the Chrome ext).
+    const ctx = getBrowserContext()
+    const tracks = seedFixtures.flatMap((fixture) => beatportTracksTransform(fixture))
+    const res = await ctx.request.post(`${process.env.PREVIEW_URL}/api/me/tracks`, {
+      data: tracks,
+      headers: { 'x-multi-store-player-store': beatportUrl },
+    })
+    if (!res.ok()) throw new Error(`Seeding tracks failed: HTTP ${res.status()} — ${await res.text()}`)
+    return { addedTracks: [], addedSources: [] }
+  }
+
   return setupBeatportTracks(seedFixtures.map((tracks) => ({ tracks })), false, userIds)
 }
 

--- a/packages/back/test/lib/setup.js
+++ b/packages/back/test/lib/setup.js
@@ -91,149 +91,6 @@ const dismissOnboarding = async (page) => {
   )
 }
 
-// Injected into every page in remote demo mode to visualise cursor, clicks,
-// keyboard events, and scroll direction.
-const demoOverlay = () => {
-  const cursor = document.createElement('div')
-  Object.assign(cursor.style, {
-    position: 'fixed',
-    width: '28px',
-    height: '28px',
-    borderRadius: '50%',
-    border: '3px solid rgba(255,120,0,.9)',
-    backgroundColor: 'rgba(255,120,0,.15)',
-    boxShadow: '0 0 8px rgba(255,120,0,.5)',
-    pointerEvents: 'none',
-    zIndex: '2147483647',
-    transform: 'translate(-50%,-50%)',
-    transition: 'transform .08s,background-color .08s',
-    display: 'none',
-  })
-  document.addEventListener('mousemove', (e) => {
-    cursor.style.display = 'block'
-    cursor.style.left = e.clientX + 'px'
-    cursor.style.top = e.clientY + 'px'
-  })
-  document.addEventListener('mousedown', () => {
-    cursor.style.backgroundColor = 'rgba(255,120,0,.5)'
-    cursor.style.transform = 'translate(-50%,-50%) scale(.75)'
-  })
-  document.addEventListener('mouseup', () => {
-    cursor.style.backgroundColor = 'rgba(255,120,0,.15)'
-    cursor.style.transform = 'translate(-50%,-50%) scale(1)'
-  })
-
-  const spawnRipple = (x, y) => {
-    const r = document.createElement('div')
-    Object.assign(r.style, {
-      position: 'fixed',
-      left: x + 'px',
-      top: y + 'px',
-      width: '50px',
-      height: '50px',
-      borderRadius: '50%',
-      border: '2px solid rgba(255,120,0,.8)',
-      backgroundColor: 'rgba(255,120,0,.2)',
-      transform: 'translate(-50%,-50%) scale(0)',
-      pointerEvents: 'none',
-      zIndex: '2147483646',
-    })
-    document.body.appendChild(r)
-    r.animate(
-      [
-        { transform: 'translate(-50%,-50%) scale(0)', opacity: 1 },
-        { transform: 'translate(-50%,-50%) scale(2.5)', opacity: 0 },
-      ],
-      { duration: 500, easing: 'ease-out' },
-    ).onfinish = () => r.remove()
-  }
-  document.addEventListener('click', (e) => spawnRipple(e.clientX, e.clientY))
-  document.addEventListener('contextmenu', (e) => spawnRipple(e.clientX, e.clientY))
-
-  const kbd = document.createElement('div')
-  Object.assign(kbd.style, {
-    position: 'fixed',
-    bottom: '24px',
-    left: '50%',
-    transform: 'translateX(-50%)',
-    backgroundColor: 'rgba(0,0,0,.82)',
-    color: '#fff',
-    borderRadius: '10px',
-    padding: '10px 20px',
-    fontSize: '17px',
-    fontFamily: '"SF Mono","Fira Code",monospace',
-    pointerEvents: 'none',
-    zIndex: '2147483647',
-    display: 'none',
-    whiteSpace: 'nowrap',
-    boxShadow: '0 4px 12px rgba(0,0,0,.4)',
-  })
-  const heldKeys = new Set()
-  let kbdTimer
-  document.addEventListener('keydown', (e) => {
-    if (!e.repeat) heldKeys.add(e.key)
-    clearTimeout(kbdTimer)
-    if (heldKeys.size > 0) {
-      kbd.style.display = 'block'
-      kbd.textContent = [...heldKeys].map((k) => (k.length === 1 ? k : `[${k}]`)).join(' + ')
-    }
-  })
-  document.addEventListener('keyup', (e) => {
-    heldKeys.delete(e.key)
-    if (heldKeys.size > 0) {
-      kbd.textContent = [...heldKeys].map((k) => (k.length === 1 ? k : `[${k}]`)).join(' + ')
-    } else {
-      kbdTimer = setTimeout(() => {
-        kbd.style.display = 'none'
-        kbd.textContent = ''
-      }, 700)
-    }
-  })
-
-  const scrollEl = document.createElement('div')
-  Object.assign(scrollEl.style, {
-    position: 'fixed',
-    right: '20px',
-    top: '50%',
-    transform: 'translateY(-50%)',
-    backgroundColor: 'rgba(0,0,0,.75)',
-    color: '#fff',
-    borderRadius: '10px',
-    padding: '10px 12px',
-    fontSize: '22px',
-    pointerEvents: 'none',
-    zIndex: '2147483647',
-    display: 'none',
-    boxShadow: '0 4px 12px rgba(0,0,0,.4)',
-  })
-  let scrollTimer
-  document.addEventListener(
-    'scroll',
-    (e) => {
-      const t = e.target
-      const prev = t._demoScrollTop ?? 0
-      const cur = t === document ? window.scrollY : t.scrollTop
-      t._demoScrollTop = cur
-      scrollEl.textContent = cur > prev ? '↓' : '↑'
-      scrollEl.style.display = 'block'
-      clearTimeout(scrollTimer)
-      scrollTimer = setTimeout(() => (scrollEl.style.display = 'none'), 700)
-    },
-    true,
-  )
-
-  const mount = () => {
-    document.body.appendChild(cursor)
-    document.body.appendChild(kbd)
-    document.body.appendChild(scrollEl)
-  }
-  if (document.body) {
-    mount()
-  } else {
-    document.addEventListener('DOMContentLoaded', mount)
-  }
-}
-
 const initialize = async () => {
   let baseURL, server
 
@@ -265,9 +122,12 @@ const initialize = async () => {
   }
   sharedBrowserContext = await sharedBrowser.newContext(contextOptions)
 
-  if (isRemotePreview) {
-    await sharedBrowserContext.addInitScript(demoOverlay)
-  } else {
+  const tracePath = process.env.TRACE_PATH
+  if (tracePath) {
+    await sharedBrowserContext.tracing.start({ screenshots: true, snapshots: true, sources: true })
+  }
+
+  if (!isRemotePreview) {
     await sharedBrowserContext.route('**/*', async (route) => {
       const requestUrl = new URL(route.request().url())
       if (!requestUrl.pathname.startsWith('/api/')) {
@@ -326,9 +186,12 @@ const initialize = async () => {
     process.on('exit', () => server.kill())
   }
 
-  // Finalize video recording (if active) before process exits.
+  // Finalize video + trace recording (if active) before process exits.
   process.on('beforeExit', async () => {
     if (sharedBrowserContext) {
+      if (tracePath) {
+        await sharedBrowserContext.tracing.stop({ path: tracePath }).catch(() => {})
+      }
       await sharedBrowserContext.close().catch(() => {})
       sharedBrowserContext = null
     }

--- a/packages/back/test/lib/setup.js
+++ b/packages/back/test/lib/setup.js
@@ -5,10 +5,15 @@ const { initDb } = require('./db')
 const { startServer } = require('./server')
 
 let initPromise = null
+let sharedBrowserContext = null
+let sharedBrowser = null
+
 const BACKEND_ROOT = path.resolve(__dirname, '../..')
 const FRONTEND_ROOT = path.resolve(BACKEND_ROOT, '../front')
 const FRONTEND_SOURCE_PATHS = ['src', 'public', 'package.json'].map((entry) => path.join(FRONTEND_ROOT, entry))
 const FRONTEND_BUILD_PATH = path.join(BACKEND_ROOT, 'public')
+
+const isRemotePreview = Boolean(process.env.PREVIEW_URL)
 
 const getLatestMtimeMs = async (targetPath) => {
   let stats
@@ -86,58 +91,230 @@ const dismissOnboarding = async (page) => {
   )
 }
 
-const initialize = async () => {
-  await initDb()
-  await warnIfFrontendBuildIsOutdated()
+// Injected into every page in remote demo mode to visualise cursor, clicks,
+// keyboard events, and scroll direction.
+const demoOverlay = () => {
+  const cursor = document.createElement('div')
+  Object.assign(cursor.style, {
+    position: 'fixed',
+    width: '28px',
+    height: '28px',
+    borderRadius: '50%',
+    border: '3px solid rgba(255,120,0,.9)',
+    backgroundColor: 'rgba(255,120,0,.15)',
+    boxShadow: '0 0 8px rgba(255,120,0,.5)',
+    pointerEvents: 'none',
+    zIndex: '2147483647',
+    transform: 'translate(-50%,-50%)',
+    transition: 'transform .08s,background-color .08s',
+    display: 'none',
+  })
+  document.addEventListener('mousemove', (e) => {
+    cursor.style.display = 'block'
+    cursor.style.left = e.clientX + 'px'
+    cursor.style.top = e.clientY + 'px'
+  })
+  document.addEventListener('mousedown', () => {
+    cursor.style.backgroundColor = 'rgba(255,120,0,.5)'
+    cursor.style.transform = 'translate(-50%,-50%) scale(.75)'
+  })
+  document.addEventListener('mouseup', () => {
+    cursor.style.backgroundColor = 'rgba(255,120,0,.15)'
+    cursor.style.transform = 'translate(-50%,-50%) scale(1)'
+  })
 
-  const { server, port } = await startServer()
-  console.log(`[browser-test] Using server port ${port}`)
-  const baseURL = `http://localhost:${port}`
+  const spawnRipple = (x, y) => {
+    const r = document.createElement('div')
+    Object.assign(r.style, {
+      position: 'fixed',
+      left: x + 'px',
+      top: y + 'px',
+      width: '50px',
+      height: '50px',
+      borderRadius: '50%',
+      border: '2px solid rgba(255,120,0,.8)',
+      backgroundColor: 'rgba(255,120,0,.2)',
+      transform: 'translate(-50%,-50%) scale(0)',
+      pointerEvents: 'none',
+      zIndex: '2147483646',
+    })
+    document.body.appendChild(r)
+    r.animate(
+      [
+        { transform: 'translate(-50%,-50%) scale(0)', opacity: 1 },
+        { transform: 'translate(-50%,-50%) scale(2.5)', opacity: 0 },
+      ],
+      { duration: 500, easing: 'ease-out' },
+    ).onfinish = () => r.remove()
+  }
+  document.addEventListener('click', (e) => spawnRipple(e.clientX, e.clientY))
+  document.addEventListener('contextmenu', (e) => spawnRipple(e.clientX, e.clientY))
+
+  const kbd = document.createElement('div')
+  Object.assign(kbd.style, {
+    position: 'fixed',
+    bottom: '24px',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    backgroundColor: 'rgba(0,0,0,.82)',
+    color: '#fff',
+    borderRadius: '10px',
+    padding: '10px 20px',
+    fontSize: '17px',
+    fontFamily: '"SF Mono","Fira Code",monospace',
+    pointerEvents: 'none',
+    zIndex: '2147483647',
+    display: 'none',
+    whiteSpace: 'nowrap',
+    boxShadow: '0 4px 12px rgba(0,0,0,.4)',
+  })
+  const heldKeys = new Set()
+  let kbdTimer
+  document.addEventListener('keydown', (e) => {
+    if (!e.repeat) heldKeys.add(e.key)
+    clearTimeout(kbdTimer)
+    if (heldKeys.size > 0) {
+      kbd.style.display = 'block'
+      kbd.textContent = [...heldKeys].map((k) => (k.length === 1 ? k : `[${k}]`)).join(' + ')
+    }
+  })
+  document.addEventListener('keyup', (e) => {
+    heldKeys.delete(e.key)
+    if (heldKeys.size > 0) {
+      kbd.textContent = [...heldKeys].map((k) => (k.length === 1 ? k : `[${k}]`)).join(' + ')
+    } else {
+      kbdTimer = setTimeout(() => {
+        kbd.style.display = 'none'
+        kbd.textContent = ''
+      }, 700)
+    }
+  })
+
+  const scrollEl = document.createElement('div')
+  Object.assign(scrollEl.style, {
+    position: 'fixed',
+    right: '20px',
+    top: '50%',
+    transform: 'translateY(-50%)',
+    backgroundColor: 'rgba(0,0,0,.75)',
+    color: '#fff',
+    borderRadius: '10px',
+    padding: '10px 12px',
+    fontSize: '22px',
+    pointerEvents: 'none',
+    zIndex: '2147483647',
+    display: 'none',
+    boxShadow: '0 4px 12px rgba(0,0,0,.4)',
+  })
+  let scrollTimer
+  document.addEventListener(
+    'scroll',
+    (e) => {
+      const t = e.target
+      const prev = t._demoScrollTop ?? 0
+      const cur = t === document ? window.scrollY : t.scrollTop
+      t._demoScrollTop = cur
+      scrollEl.textContent = cur > prev ? '↓' : '↑'
+      scrollEl.style.display = 'block'
+      clearTimeout(scrollTimer)
+      scrollTimer = setTimeout(() => (scrollEl.style.display = 'none'), 700)
+    },
+    true,
+  )
+
+  const mount = () => {
+    document.body.appendChild(cursor)
+    document.body.appendChild(kbd)
+    document.body.appendChild(scrollEl)
+  }
+  if (document.body) {
+    mount()
+  } else {
+    document.addEventListener('DOMContentLoaded', mount)
+  }
+}
+
+const initialize = async () => {
+  let baseURL, server
+
+  if (isRemotePreview) {
+    baseURL = process.env.PREVIEW_URL
+    server = null
+  } else {
+    await initDb()
+    await warnIfFrontendBuildIsOutdated()
+    const result = await startServer()
+    console.log(`[browser-test] Using server port ${result.port}`)
+    server = result.server
+    baseURL = `http://localhost:${result.port}`
+  }
 
   const headed = process.env.PW_HEADED === '1' || process.env.PWDEBUG === '1'
-  const slowMoValue = process.env.PW_SLOWMO ?? process.env.PW_SLOMO ?? '0'
+  const slowMoValue = process.env.PW_SLOWMO ?? process.env.PW_SLOMO ?? (isRemotePreview ? '600' : '0')
   const slowMo = Number(slowMoValue)
-  const browser = await chromium.launch({
+
+  sharedBrowser = await chromium.launch({
     headless: !headed,
     slowMo: Number.isFinite(slowMo) ? slowMo : 0,
   })
-  const context = await browser.newContext({ baseURL })
 
-  await context.route('**/*', async (route) => {
-    const requestUrl = new URL(route.request().url())
-    if (!requestUrl.pathname.startsWith('/api/')) {
-      await route.continue()
-      return
-    }
+  const videoDir = process.env.VIDEO_DIR
+  const contextOptions = { baseURL }
+  if (videoDir) {
+    contextOptions.recordVideo = { dir: videoDir, size: { width: 1280, height: 720 } }
+  }
+  sharedBrowserContext = await sharedBrowser.newContext(contextOptions)
 
-    const targetUrl = `${baseURL}${requestUrl.pathname}${requestUrl.search}`
-    await route.continue({ url: targetUrl })
-  })
+  if (isRemotePreview) {
+    await sharedBrowserContext.addInitScript(demoOverlay)
+  } else {
+    await sharedBrowserContext.route('**/*', async (route) => {
+      const requestUrl = new URL(route.request().url())
+      if (!requestUrl.pathname.startsWith('/api/')) {
+        await route.continue()
+        return
+      }
+      const targetUrl = `${baseURL}${requestUrl.pathname}${requestUrl.search}`
+      await route.continue({ url: targetUrl })
+    })
+  }
 
-  const page = await context.newPage()
+  const page = await sharedBrowserContext.newPage()
   await page.goto('/tracks/recent')
 
-  const loginStatus = await page.evaluate(async () => {
-    const res = await fetch('/api/auth/login', {
-      method: 'POST',
-      credentials: 'same-origin',
-      mode: 'same-origin',
-      redirect: 'follow',
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-      },
-      body: JSON.stringify({ username: 'testuser', password: 'testpwd' }),
+  if (isRemotePreview) {
+    const oidcToken = process.env.OIDC_TOKEN
+    if (!oidcToken) throw new Error('OIDC_TOKEN env var is required for remote preview login')
+    const loginRes = await page.request.post(`${baseURL}/api/auth/login/actions`, {
+      data: { token: oidcToken },
     })
-    return res.status
-  })
-  if (loginStatus !== 204) {
-    throw new Error(`Login failed with status ${loginStatus}`)
+    if (!loginRes.ok()) {
+      throw new Error(`Remote preview OIDC login failed: HTTP ${loginRes.status()} — ${await loginRes.text()}`)
+    }
+  } else {
+    const loginStatus = await page.evaluate(async () => {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        credentials: 'same-origin',
+        mode: 'same-origin',
+        redirect: 'follow',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({ username: 'testuser', password: 'testpwd' }),
+      })
+      return res.status
+    })
+    if (loginStatus !== 204) {
+      throw new Error(`Login failed with status ${loginStatus}`)
+    }
+    const sessionCookies = await sharedBrowserContext.cookies(baseURL)
+    if (!sessionCookies.some(({ name }) => name === 'connect.sid')) {
+      throw new Error('Login did not establish a session cookie')
+    }
   }
-  const sessionCookies = await context.cookies(baseURL)
-  if (!sessionCookies.some(({ name }) => name === 'connect.sid')) {
-    throw new Error('Login did not establish a session cookie')
-  }
+
   await page.goto('/tracks/recent')
   await waitForWithTimeoutMessage(
     () => page.waitForSelector('.tracks-table', { timeout: 15000 }),
@@ -145,9 +322,23 @@ const initialize = async () => {
   )
   await dismissOnboarding(page)
 
-  process.on('exit', () => server.kill())
+  if (server) {
+    process.on('exit', () => server.kill())
+  }
 
-  return { server, browser, context, page }
+  // Finalize video recording (if active) before process exits.
+  process.on('beforeExit', async () => {
+    if (sharedBrowserContext) {
+      await sharedBrowserContext.close().catch(() => {})
+      sharedBrowserContext = null
+    }
+    if (sharedBrowser) {
+      await sharedBrowser.close().catch(() => {})
+      sharedBrowser = null
+    }
+  })
+
+  return { server, browser: sharedBrowser, context: sharedBrowserContext, page }
 }
 
 module.exports.getSharedContext = () => {
@@ -156,6 +347,8 @@ module.exports.getSharedContext = () => {
   }
   return initPromise
 }
+
+module.exports.getBrowserContext = () => sharedBrowserContext
 
 module.exports.dismissOnboarding = dismissOnboarding
 module.exports.waitForWithTimeoutMessage = waitForWithTimeoutMessage

--- a/packages/back/test/lib/test-user.js
+++ b/packages/back/test/lib/test-user.js
@@ -1,7 +1,20 @@
 const account = require('../../db/account')
 const { pg } = require('./db')
+const { getBrowserContext } = require('./setup')
+
+const isRemotePreview = Boolean(process.env.PREVIEW_URL)
 
 module.exports.resolveTestUserId = async () => {
+  if (isRemotePreview) {
+    // Bot user was created when logging in via GitHub Actions OIDC. Fetch their
+    // ID from the session using the browser context's cookie jar.
+    const ctx = getBrowserContext()
+    const res = await ctx.request.get(`${process.env.PREVIEW_URL}/api/auth/me`)
+    if (!res.ok()) throw new Error(`GET /api/auth/me failed: HTTP ${res.status()}`)
+    const { id } = await res.json()
+    return id
+  }
+
   const authResult = await account.authenticate('testuser', 'testpwd')
   if (!authResult?.id) {
     throw new Error('Could not resolve test user id')

--- a/packages/back/test/tests/users/auth/actions-oidc-login.js
+++ b/packages/back/test/tests/users/auth/actions-oidc-login.js
@@ -1,0 +1,124 @@
+'use strict'
+
+const { expect } = require('chai')
+const express = require('express')
+const request = require('supertest')
+const { test } = require('cascade-test')
+const { createAuthRouter } = require('../../../../routes/auth')
+
+const FRONTEND_URL = 'https://preview.fomoplayer.com'
+const API_ORIGIN = 'https://preview-pr-1.up.railway.app'
+const ALLOWED_REPO = 'owner/fomoplayer'
+
+const previewConfig = {
+  frontendURL: FRONTEND_URL,
+  apiOrigin: API_ORIGIN,
+  allowedOrigins: [],
+  allowedOriginRegexes: [],
+  oidcHandoffUrl: undefined,
+  oidcHandoffAuthorityOrigin: undefined,
+  oidcHandoffSecret: undefined,
+  maxAccountCount: 5,
+  isPreviewEnv: true,
+  githubActionsOidcRepo: ALLOWED_REPO,
+}
+
+const mockAccount = (userId = 42) => ({
+  findOrCreateByIdentifier: async () => ({ id: userId }),
+  findByIdentifier: async () => null,
+  findByUserId: async () => ({ id: userId }),
+})
+
+const createApp = ({ config = previewConfig, account = mockAccount(), verifyActionsTokenFn } = {}) => {
+  const app = express()
+  app.use(express.json())
+  app.use((req, _, next) => {
+    req.session = {}
+    req.login = (user, cb) => {
+      req.user = user
+      cb()
+    }
+    next()
+  })
+  app.use('/api/auth', createAuthRouter({ account, config, verifyActionsTokenFn }))
+  return app
+}
+
+const validPayload = () => ({ repository: ALLOWED_REPO, iss: 'https://token.actions.githubusercontent.com' })
+
+test({
+  'POST /login/actions — valid token returns 204 and establishes session': async () => {
+    const app = createApp({ verifyActionsTokenFn: async () => validPayload() })
+    const response = await request(app)
+      .post('/api/auth/login/actions')
+      .send({ token: 'valid-actions-token' })
+    expect(response.status).to.equal(204)
+  },
+
+  'POST /login/actions — invalid token returns 401': async () => {
+    const app = createApp({ verifyActionsTokenFn: async () => null })
+    const response = await request(app)
+      .post('/api/auth/login/actions')
+      .send({ token: 'tampered-token' })
+    expect(response.status).to.equal(401)
+  },
+
+  'POST /login/actions — missing token body returns 400': async () => {
+    const app = createApp({ verifyActionsTokenFn: async () => validPayload() })
+    const response = await request(app)
+      .post('/api/auth/login/actions')
+      .send({})
+    expect(response.status).to.equal(400)
+  },
+
+  'POST /login/actions — absent when isPreviewEnv is false': async () => {
+    const app = createApp({
+      config: { ...previewConfig, isPreviewEnv: false },
+      verifyActionsTokenFn: async () => validPayload(),
+    })
+    const response = await request(app)
+      .post('/api/auth/login/actions')
+      .send({ token: 'valid-actions-token' })
+    expect(response.status).to.equal(404)
+  },
+
+  'POST /login/actions — absent when githubActionsOidcRepo is not configured': async () => {
+    const app = createApp({
+      config: { ...previewConfig, githubActionsOidcRepo: undefined },
+      verifyActionsTokenFn: async () => validPayload(),
+    })
+    const response = await request(app)
+      .post('/api/auth/login/actions')
+      .send({ token: 'valid-actions-token' })
+    expect(response.status).to.equal(404)
+  },
+
+  'POST /login/actions — verifyActionsToken is called with apiOrigin as audience and configured repo': async () => {
+    let capturedArgs
+    const app = createApp({
+      verifyActionsTokenFn: async (args) => {
+        capturedArgs = args
+        return validPayload()
+      },
+    })
+    await request(app).post('/api/auth/login/actions').send({ token: 'my-token' })
+    expect(capturedArgs.token).to.equal('my-token')
+    expect(capturedArgs.audience).to.equal(API_ORIGIN)
+    expect(capturedArgs.allowedRepo).to.equal(ALLOWED_REPO)
+  },
+
+  'POST /login/actions — uses findOrCreateByIdentifier with GitHub Actions issuer and repo as subject': async () => {
+    let capturedIssuer, capturedSubject
+    const account = {
+      findOrCreateByIdentifier: async (issuer, subject) => {
+        capturedIssuer = issuer
+        capturedSubject = subject
+        return { id: 7 }
+      },
+    }
+    const app = createApp({ account, verifyActionsTokenFn: async () => validPayload() })
+    await request(app).post('/api/auth/login/actions').send({ token: 'my-token' })
+    expect(capturedIssuer).to.equal('token.actions.githubusercontent.com')
+    expect(capturedSubject).to.equal(ALLOWED_REPO)
+  },
+})


### PR DESCRIPTION
## Summary
- New `.github/workflows/pr-demo.yml` runs a Playwright browser test against the Railway PR preview when a PR carries the `demo-test` label, records a slow-mo video **and** a Playwright trace, and uploads both as a single workflow artifact.
- Backend gains `POST /api/auth/login/actions` (only registered when `IS_PREVIEW_ENV=true` and `GITHUB_ACTIONS_OIDC_REPO` matches the calling repo) that verifies a GitHub Actions OIDC token via JWKS with audience bound to the preview URL, plus `GET /api/auth/me` and `GET /api/health` for the workflow's polling/identification needs.
- Test infrastructure (`setup.js`, `seed.js`, `test-user.js`) gains a remote-preview path: seeding via the public tracks endpoint, bot-user resolution via `/api/auth/me`, and Playwright `recordVideo` + `tracing.start({ screenshots, snapshots, sources })` driven by `VIDEO_DIR` / `TRACE_PATH`. No bespoke DOM overlay — the trace viewer renders mouse pointer, click highlights, network, console and DOM snapshots natively.
- New `packages/back/test/browser/demo.js` is the default walkthrough: select a track, play, pause, add to cart, open cart, verify.
- `docs/auth/oidc-login-flow.md` documents all login flows including the new Actions OIDC bot path.

## How it works
1. Maintainer applies the `demo-test` label to a PR.
2. Workflow polls the Railway preview's `/api/health` until ready (5 min timeout).
3. PR body provides the test path inside a fenced `demo-test` block (see below).
4. Workflow mints an OIDC token with audience = preview URL, posts to `/api/auth/login/actions` to establish a session, runs `cascade-test` against the preview with slow-mo + video + trace, and uploads both artifacts.
5. Workflow comments on the PR with a link to the artifact and to [trace.playwright.dev](https://trace.playwright.dev/) for opening the trace.

## Configuration required
- Preview backend env (Railway dashboard): `IS_PREVIEW_ENV=true`, `GITHUB_ACTIONS_OIDC_REPO=gadgetmies/fomoplayer`, `PREVIEW_ALLOWED_GOOGLE_SUBS=...`.
- Service/environment names (`fomoplayer`, `fomoplayer-pr-<N>`) are hard-coded in the workflow — they're already public on every preview URL, so no repo vars are needed.

## Demo test targeted by this workflow

```demo-test
test/browser/demo.js
```

## Test plan
- [ ] Set `IS_PREVIEW_ENV=true` and `GITHUB_ACTIONS_OIDC_REPO=gadgetmies/fomoplayer` on the preview backend env in Railway.
- [ ] Apply the `demo-test` label to this PR; confirm the workflow runs end-to-end against the Railway preview.
- [ ] Confirm the artifact contains a `*.webm` video and a `trace.zip`.
- [ ] Open `trace.zip` at https://trace.playwright.dev/ and confirm the walkthrough is fully scrubbable.
- [ ] Confirm the workflow comments on the PR with the trace link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)