### PR TITLE
Add configurable media button behavior for desktop and mobile

### DIFF
--- a/packages/front/src/Player.js
+++ b/packages/front/src/Player.js
@@ -291,6 +291,7 @@ class Player extends Component {
           stores={this.props.stores}
           togglingCurrentInCart={this.state.togglingCurrentInCart}
           totalTracks={this.props.meta ? this.props.meta.totalTracks : null}
+          isMobile={this.props.isMobile}
           ref={this.preview}
           markHeard={this.markHeard.bind(this)}
           onCartButtonClick={this.props.onHandleCartButtonClick?.bind(this)}

--- a/packages/front/src/PlayerHelp.js
+++ b/packages/front/src/PlayerHelp.js
@@ -59,10 +59,10 @@ export class PlayerHelp extends Component {
       content: (
         <p>
           The player can be controlled using media keys on your keyboard even when the player is running in the
-          background. To make the browsing experience smoother, the fast forward and rewind buttons do not skip complete
-          tracks, but instead seek the track back and forward. To jump to the next / previous track, you need to double
-          click those keys. There are also other useful shortcuts to make the use more efficient. You can see these by
-          hovering the keyboard icon in the top bar.
+          background. By default the fast forward and rewind buttons do not skip complete tracks, but instead seek the
+          track back and forward and double clicking those keys will jump to the next / previous track. This behavior
+          can be changed from the player settings. There are also other useful shortcuts to make the use more efficient.
+          You can see these by hovering the keyboard icon in the top bar.
         </p>
       ),
       locale: { last: 'Done' },

--- a/packages/front/src/Preview.js
+++ b/packages/front/src/Preview.js
@@ -258,30 +258,44 @@ class Preview extends Component {
   }
 
   async handleNextClick() {
-    if (this.state.nextDoubleClickStarted) {
-      this.setState({ nextDoubleClickStarted: false })
+    const behavior = localStorage.getItem('mediaButtonBehavior')
+    if (behavior === 'skip') {
       await this.props.onNext()
     } else {
-      const that = this
-      this.setState({ nextDoubleClickStarted: true })
-      setTimeout(() => {
-        that.setState({ nextDoubleClickStarted: false })
-      }, 200)
-      this.seekForward()
+      if (this.state.nextDoubleClickStarted) {
+        this.setState({ nextDoubleClickStarted: false })
+        await this.props.onNext()
+      } else {
+        const that = this
+        this.setState({ nextDoubleClickStarted: true })
+        setTimeout(() => {
+          that.setState({ nextDoubleClickStarted: false })
+        }, 200)
+        this.seekForward()
+      }
     }
   }
 
   async handlePreviousClick() {
-    if (this.state.previousDoubleClickStarted) {
-      this.setState({ previousDoubleClickStarted: false })
-      await this.props.onPrevious()
+    const behavior = localStorage.getItem('mediaButtonBehavior')
+    if (behavior === 'skip') {
+      if (this.getPlayer().currentTime > 2) {
+        this.getPlayer().currentTime = 0
+      } else {
+        await this.props.onPrevious()
+      }
     } else {
-      const that = this
-      this.setState({ previousDoubleClickStarted: true })
-      setTimeout(() => {
-        that.setState({ previousDoubleClickStarted: false })
-      }, 200)
-      this.seekBackward()
+      if (this.state.previousDoubleClickStarted) {
+        this.setState({ previousDoubleClickStarted: false })
+        await this.props.onPrevious()
+      } else {
+        const that = this
+        this.setState({ previousDoubleClickStarted: true })
+        setTimeout(() => {
+          that.setState({ previousDoubleClickStarted: false })
+        }, 200)
+        this.seekBackward()
+      }
     }
   }
 

--- a/packages/front/src/Settings.js
+++ b/packages/front/src/Settings.js
@@ -140,6 +140,7 @@ class Settings extends Component {
       editingCartNameId: null,
       cartNameEditorValue: '',
       cloningCartId: null,
+      mediaButtonBehavior: localStorage.getItem('mediaButtonBehavior') || 'seek',
       audioSamples: [],
       uploadingAudioSample: false,
       deletingAudioSample: null,
@@ -587,6 +588,20 @@ class Settings extends Component {
                   </label>
                 </>
               )}
+              <input
+                type="radio"
+                id="settings-state-player"
+                name="settings-state"
+                checked={this.state.page === 'player'}
+                onChange={() => this.onShowPage('player')}
+              />
+              <label
+                className="select_button-button select_button-button__large"
+                htmlFor="settings-state-player"
+                data-help-id="player-tab"
+              >
+                Player
+              </label>
             </div>
           </div>
           {this.state.page === 'following' ? (
@@ -1513,6 +1528,42 @@ class Settings extends Component {
                 {this.markHeardButton('Tracks older than two years', '2 years')}
               </p>
               <p className="input-layout">{this.markHeardButton('All tracks', '0')}</p>
+            </>
+          ) : null}
+          {this.state.page === 'player' ? (
+            <>
+              <h4>Media button behavior</h4>
+              <p>
+                Configure how the next and previous media buttons on your device (keyboard, headphones, etc.) behave.
+              </p>
+              <div className="select-button select-button--container state-select-button--container noselect">
+                <input
+                  type="radio"
+                  id="media-button-behavior-seek"
+                  name="media-button-behavior"
+                  checked={this.state.mediaButtonBehavior === 'seek'}
+                  onChange={() => {
+                    localStorage.setItem('mediaButtonBehavior', 'seek')
+                    this.setState({ mediaButtonBehavior: 'seek' })
+                  }}
+                />
+                <label className="select_button-button" htmlFor="media-button-behavior-seek">
+                  Seek (double click to skip)
+                </label>
+                <input
+                  type="radio"
+                  id="media-button-behavior-skip"
+                  name="media-button-behavior"
+                  checked={this.state.mediaButtonBehavior === 'skip'}
+                  onChange={() => {
+                    localStorage.setItem('mediaButtonBehavior', 'skip')
+                    this.setState({ mediaButtonBehavior: 'skip' })
+                  }}
+                />
+                <label className="select_button-button" htmlFor="media-button-behavior-skip">
+                  Skip
+                </label>
+              </div>
             </>
           ) : null}
           {this.state.page === 'integrations' ? (

--- a/packages/front/src/Settings.js
+++ b/packages/front/src/Settings.js
@@ -1532,16 +1532,16 @@ class Settings extends Component {
           ) : null}
           {this.state.page === 'player' ? (
             <>
-              <h4>Media button behavior</h4>
+              <h4>Fast forward button behaviour</h4>
               <p>
                 Configure how the next and previous media buttons on your device (keyboard, headphones, etc.) behave.
-                With the toggle off, a single press seeks within the current track and a double press skips to the next
-                or previous track. With the toggle on, a single press skips tracks. This setting is stored on this
-                device, so it can be configured separately for each device you use.
+                In <em>Seek</em> mode a single press seeks within the current track and a double press skips to the
+                next or previous track. In <em>Skip</em> mode a single press skips tracks. This setting is stored on
+                this device, so it can be configured separately for each device you use.
               </p>
               <p style={{ display: 'flex', alignItems: 'center', gap: 16 }} className="input-layout">
                 <label htmlFor="media-button-behavior" className="noselect">
-                  Skip tracks on single press:
+                  Fast forward button behaviour:
                 </label>
                 <ToggleButton
                   id="media-button-behavior"
@@ -1552,6 +1552,7 @@ class Settings extends Component {
                     this.setState({ mediaButtonBehavior: behavior })
                   }}
                 />
+                <span className="noselect">{this.state.mediaButtonBehavior === 'skip' ? 'Skip' : 'Seek'}</span>
               </p>
             </>
           ) : null}

--- a/packages/front/src/Settings.js
+++ b/packages/front/src/Settings.js
@@ -1535,35 +1535,24 @@ class Settings extends Component {
               <h4>Media button behavior</h4>
               <p>
                 Configure how the next and previous media buttons on your device (keyboard, headphones, etc.) behave.
+                With the toggle off, a single press seeks within the current track and a double press skips to the next
+                or previous track. With the toggle on, a single press skips tracks. This setting is stored on this
+                device, so it can be configured separately for each device you use.
               </p>
-              <div className="select-button select-button--container state-select-button--container noselect">
-                <input
-                  type="radio"
-                  id="media-button-behavior-seek"
-                  name="media-button-behavior"
-                  checked={this.state.mediaButtonBehavior === 'seek'}
-                  onChange={() => {
-                    localStorage.setItem('mediaButtonBehavior', 'seek')
-                    this.setState({ mediaButtonBehavior: 'seek' })
-                  }}
-                />
-                <label className="select_button-button" htmlFor="media-button-behavior-seek">
-                  Seek (double click to skip)
+              <p style={{ display: 'flex', alignItems: 'center', gap: 16 }} className="input-layout">
+                <label htmlFor="media-button-behavior" className="noselect">
+                  Skip tracks on single press:
                 </label>
-                <input
-                  type="radio"
-                  id="media-button-behavior-skip"
-                  name="media-button-behavior"
+                <ToggleButton
+                  id="media-button-behavior"
                   checked={this.state.mediaButtonBehavior === 'skip'}
-                  onChange={() => {
-                    localStorage.setItem('mediaButtonBehavior', 'skip')
-                    this.setState({ mediaButtonBehavior: 'skip' })
+                  onChange={(state) => {
+                    const behavior = state ? 'skip' : 'seek'
+                    localStorage.setItem('mediaButtonBehavior', behavior)
+                    this.setState({ mediaButtonBehavior: behavior })
                   }}
                 />
-                <label className="select_button-button" htmlFor="media-button-behavior-skip">
-                  Skip
-                </label>
-              </div>
+              </p>
             </>
           ) : null}
           {this.state.page === 'integrations' ? (

--- a/packages/front/src/SettingsHelp.js
+++ b/packages/front/src/SettingsHelp.js
@@ -95,6 +95,17 @@ export class SettingsHelp extends Component {
           reasons the service will only modify playlists it has created.
         </p>
       ),
+    },
+    Player: {
+      target: '[data-help-id=player-tab]',
+      placement: 'bottom',
+      content: (
+        <p>
+          In the player tab you can configure the behavior of the media buttons on your device. You can choose between
+          the default behavior (single click to seek, double click to skip) and a skip behavior (single click to skip
+          to the next track or to the beginning/previous track).
+        </p>
+      ),
       locale: { last: 'Done' },
     },
   }


### PR DESCRIPTION
- Add "Player" tab to settings to configure media button behavior.
- Support "Seek" (default) and "Skip" behaviors.
- Allow separate configuration for desktop and mobile.
- Update Preview.js to respect the new settings.
- Update help components with new configuration details.

Co-authored-by: gadgetmies <71213783+gadgetmies@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Player settings page with a toggle to choose media button behavior: single-press can either skip tracks or seek within the current track.
  * Media button handling updated so behavior follows the selected setting.

* **Documentation**
  * Help text and settings help updated to explain the new Player tab and media button navigation options.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gadgetmies/fomoplayer/pull/342)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->