### PR TITLE
refactor(carts): drop redundant pagination UI in favor of infinite scroll

### DIFF
--- a/packages/front/src/App.js
+++ b/packages/front/src/App.js
@@ -203,7 +203,6 @@ class App extends Component {
       selectedCartUuid: undefined,
       selectedCart: undefined,
       mode: undefined,
-      tracksOffset: 0,
       loadingMore: false,
       trackOffsets: { new: 0, heard: 0, recent: 0, search: 0 },
       pagination: null,
@@ -309,9 +308,8 @@ class App extends Component {
 
     if (isCartPath && pathParts.length > 1 && pathParts[1] !== '') {
       const cartUuid = pathParts[1]
-      const filter = location.search
       // TODO: this causes a race condition with the initial cart fetch causing only the selected cart to be visible in the UI
-      cartSelectPromise = this.selectCart(cartUuid, filter)
+      cartSelectPromise = this.selectCart(cartUuid)
 
       const initialPosition = parseInt(location.hash.substring(1)) || undefined
       sharedStates = { initialPosition }
@@ -413,11 +411,6 @@ class App extends Component {
       ) {
         nextState.selectedCartUuid = selectedCartUuid
         nextState.selectedCart = selectedCart
-        shouldSetState = true
-      }
-      const tracksOffset = parseInt(searchParams.get('offset') || 0)
-      if (tracksOffset !== this.state.tracksOffset) {
-        nextState.tracksOffset = tracksOffset
         shouldSetState = true
       }
     }
@@ -973,11 +966,9 @@ class App extends Component {
     })
   }
 
-  async selectCart(selectedCartUuid, filter) {
+  async selectCart(selectedCartUuid) {
     this.setState({ selectedCartUuid, fetchingCartDetails: true, cartPagination: null })
-    const baseQuery = `offset=0&limit=${CART_TRACKS_PAGE_SIZE}`
-    const filterQuery = filter ? filter.replace(/^[?&]/, '') : ''
-    const path = `/carts/${selectedCartUuid}?${baseQuery}${filterQuery ? `&${filterQuery}` : ''}`
+    const path = `/carts/${selectedCartUuid}?offset=0&limit=${CART_TRACKS_PAGE_SIZE}`
     const cartDetails = await requestJSONwithCredentials({ path })
     let updatedCarts = this.state.carts.slice()
     let cartIndex = updatedCarts.findIndex(({ uuid }) => uuid === selectedCartUuid)
@@ -1270,7 +1261,6 @@ class App extends Component {
                           totalTracks={this.state.tracksData.meta.totalTracks}
                           tracks={this.state.tracksData.tracks}
                           markHeard={this.markHeard.bind(this)}
-                          tracksOffset={this.state.tracksOffset}
                           loadingMore={
                             listState === 'carts'
                               ? !!(this.state.cartPagination && this.state.cartPagination.loadingMore)

--- a/packages/front/src/Player.js
+++ b/packages/front/src/Player.js
@@ -320,7 +320,6 @@ class Player extends Component {
           selectedCart={this.props.selectedCart}
           selectedCartIsPurchased={selectedCartIsPurchased}
           tracks={tracks}
-          tracksOffset={this.props.tracksOffset}
           stores={this.props.stores}
           listState={this.props.listState}
           currentTrack={(currentTrack || {}).id}

--- a/packages/front/src/Tracks.js
+++ b/packages/front/src/Tracks.js
@@ -6,7 +6,7 @@ import SpinnerButton from './SpinnerButton'
 import './Select.css'
 import Track from './Track'
 import Spinner from './Spinner'
-import { Link, withRouter } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import ToggleButton from './ToggleButton'
 import GlobalSearchBar from './GlobalSearchBar'
 import Popup from './Popup'
@@ -426,17 +426,6 @@ class Tracks extends Component {
     parent.scrollBy({ top: currentRect.y - parentRect.y, behavior: 'smooth' })
   }
 
-  adjustOffset(offset) {
-    const { history } = this.props
-    const {
-      location: { pathname },
-    } = history
-    const updatedOffset = this.props.tracksOffset + offset
-    const filter = `?offset=${updatedOffset}`
-    history.push(pathname + filter)
-    this.props.onSelectCart(this.props.selectedCart.uuid, filter)
-  }
-
   onCartFilterChange(filter) {
     this.setState({ cartFilter: filter })
   }
@@ -708,8 +697,6 @@ class Tracks extends Component {
         <th>{tracks.length} results</th>
       ) : null
 
-    const multiplePages = this.props.selectedCart?.track_count > 200
-
     return (
       <div
         style={{
@@ -750,11 +737,6 @@ class Tracks extends Component {
                       />
                       <span className={'cart-details'}>
                         Tracks in cart: {this.props.selectedCart?.track_count}
-                        {multiplePages &&
-                          ` (showing ${this.props.tracksOffset + 1} - ${Math.min(
-                            this.props.tracksOffset + tracks.length,
-                            this.props.selectedCart?.track_count,
-                          )})`}
                       </span>
                     </>
                   ) : (
@@ -987,28 +969,6 @@ class Tracks extends Component {
               </td>
             </tr>
           </tbody>
-          {!this.props.preview && this.props.listState === 'carts' && multiplePages && (
-            <tfoot>
-              <tr style={{ display: 'flex', justifyContent: 'center', background: 'rgb(34, 34, 34)' }}>
-                <td style={{ display: 'flex', gap: 16, margin: 4 }}>
-                  <SpinnerButton
-                    size={isMobile ? 'small' : 'large'}
-                    loading={this.state.updatingTracks}
-                    disabled={this.props.tracksOffset === 0}
-                    onClick={this.adjustOffset.bind(this, -200)}
-                    label={'Previous page'}
-                  />
-                  <SpinnerButton
-                    size={isMobile ? 'small' : 'large'}
-                    loading={this.state.updatingTracks}
-                    disabled={tracks.length < 200}
-                    onClick={this.adjustOffset.bind(this, 200)}
-                    label={'Next page'}
-                  />
-                </td>
-              </tr>
-            </tfoot>
-          )}
           {!this.props.preview &&
             this.state.showDesktopRefresh &&
             ['new', 'recent', 'heard'].includes(this.props.listState) && (
@@ -1033,4 +993,4 @@ class Tracks extends Component {
   }
 }
 
-export default withRouter(Tracks)
+export default Tracks


### PR DESCRIPTION
Cart now loads tracks via infinite scroll, so the prev/next page buttons
and "showing X-Y" indicator are dead UI. Removes them along with the now
unused offset URL handling, adjustOffset, tracksOffset state, and the
filter argument on selectCart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cart page loading behavior with consistent, optimized data fetching

* **Refactor**
  * Removed pagination "Previous/Next" navigation controls from track listings
  * Streamlined cart selection mechanism and component architecture for better maintainability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gadgetmies/fomoplayer/pull/343)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->