### PR TITLE
Prevent accidental cart additions by restricting pause-resume shortcut sources

### DIFF
--- a/packages/front/src/Player.js
+++ b/packages/front/src/Player.js
@@ -47,7 +47,7 @@ class Player extends Component {
               await this.playPreviousTrack()
               break
             case 'w':
-              that.preview.current?.togglePlaying()
+              that.preview.current?.togglePlaying('keyboard')
               break
             case 'r':
               await this.playNextUnheard()
@@ -204,16 +204,19 @@ class Player extends Component {
     return this.props.carts.find(R.prop('is_default'))
   }
 
-  async handlePlayPauseToggle(playing) {
+  async handlePlayPauseToggle(playing, source) {
     if (this.props.mode !== 'app') return
+    const isKeyboardOrMedia = ['keyboard', 'media'].includes(source)
+
     if (playing && this.state.playPauseDoubleClickStarted) {
       this.setState({ playPauseDoubleClickStarted: false })
-      await this.props.onAddToCart(this.getDefaultCart().id, this.props.currentTrack.id)
-    } else if (!playing) {
-      const that = this
+      if (isKeyboardOrMedia) {
+        await this.props.onAddToCart(this.getDefaultCart().id, this.props.currentTrack.id)
+      }
+    } else if (!playing && isKeyboardOrMedia) {
       this.setState({ playPauseDoubleClickStarted: true })
       setTimeout(() => {
-        that.setState({ playPauseDoubleClickStarted: false })
+        this.setState({ playPauseDoubleClickStarted: false })
       }, 200)
     }
   }

--- a/packages/front/src/Preview.js
+++ b/packages/front/src/Preview.js
@@ -39,6 +39,7 @@ class Preview extends Component {
       cartFilter: '',
       embeddingMissing: true,
     }
+    this._playPauseSource = undefined
     if (window.AudioContext !== undefined) {
       this.audioContext = new AudioContext()
     }
@@ -46,11 +47,11 @@ class Preview extends Component {
     this.setVolume = this.setVolume.bind(this)
 
     const actionHandlers = [
-      ['play', this.setPlaying.bind(this, true)],
-      ['pause', this.setPlaying.bind(this, false)],
+      ['play', () => this.setPlaying(true, 'media')],
+      ['pause', () => this.setPlaying(false, 'media')],
       ['previoustrack', this.handlePreviousClick.bind(this)],
       ['nexttrack', this.handleNextClick.bind(this)],
-      ['stop', this.setPlaying.bind(this, false)],
+      ['stop', () => this.setPlaying(false, 'media')],
       ['seekbackward', ({ seekOffset }) => this.scan.bind(this, -seekOffset)],
       ['seekforward', ({ seekOffset }) => this.scan.bind(this, seekOffset)],
       [
@@ -70,12 +71,18 @@ class Preview extends Component {
     }
   }
 
-  setPlaying(playing) {
+  setPlaying(playing, source) {
+    const sourceToUse = source || this._playPauseSource
+    this._playPauseSource = undefined
+
+    if (this.state.playing === playing && !sourceToUse) return
+
     this.setState({ playing })
-    this.props.onPlayPauseToggle(playing)
+    this.props.onPlayPauseToggle(playing, sourceToUse)
   }
 
-  togglePlaying() {
+  togglePlaying(source) {
+    this._playPauseSource = source
     this.setState({ playing: !this.state.playing })
   }
 
@@ -112,7 +119,24 @@ class Preview extends Component {
     return url
   }
 
+  async prefetchTrack(track) {
+    if (!track) return
+    const previews = this.getMp3Previews(track, this.state.preferFullTracks)
+    for (const preview of previews) {
+      if (preview.url === null || (preview.store === 'bandcamp' && !preview.url.includes('token='))) {
+        try {
+          await this.fetchPreviewUrl(preview)
+        } catch (e) {
+          console.error('Pre-fetch failed', e)
+        }
+      }
+    }
+  }
   async componentDidUpdate(prevProps, prevState) {
+    if (this.props.nextTrack !== prevProps.nextTrack) {
+      this.prefetchTrack(this.props.nextTrack)
+    }
+
     if (prevState.playing !== this.state.playing) {
       const player = this.getPlayer()
       if (player) {
@@ -800,7 +824,7 @@ class Preview extends Component {
               ) : null}
             </div>
             <div className="button-wrapper">
-              <button className="button button-playback" onClick={() => this.togglePlaying()}>
+              <button className="button button-playback" onClick={() => this.togglePlaying('ui')}>
                 <FontAwesomeIcon icon={this.state.playing ? 'pause' : 'play'} />
               </button>
               <button className="button button-playback" onClick={() => this.props.onPrevious()}>

--- a/packages/shared/interceptors/interceptor.js
+++ b/packages/shared/interceptors/interceptor.js
@@ -34,7 +34,11 @@ const activeInterceptors = new Map()
 
 module.exports.init = function init({ proxies, mocks, name, regex }) {
   if (activeInterceptors.has(name)) {
-    return activeInterceptors.get(name).publicApi
+    logger.info(`Cleaning up existing interceptor for ${name}`)
+    const existing = activeInterceptors.get(name)
+    if (existing?.publicApi && typeof existing.publicApi.dispose === 'function') {
+      existing.publicApi.dispose()
+    }
   }
 
   let mockedRequests = []
@@ -49,7 +53,6 @@ module.exports.init = function init({ proxies, mocks, name, regex }) {
   })
 
   interceptor.apply()
-
   // Store the interceptor for cleanup
   const publicApi = {
     clearMockedRequests: () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Double-click play/pause to quickly add the current track to your cart (keyboard and media controls)
  * Preview URLs now prefetch automatically for upcoming tracks to enable smoother playback transitions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gadgetmies/fomoplayer/pull/344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->