### PR TITLE
Restyle settings sliders as hairline + circular brand thumb

### DIFF
--- a/openspec/changes/diagnose-pr-demo-actions-oidc-401/.openspec.yaml
+++ b/openspec/changes/diagnose-pr-demo-actions-oidc-401/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-20

--- a/openspec/changes/diagnose-pr-demo-actions-oidc-401/design.md
+++ b/openspec/changes/diagnose-pr-demo-actions-oidc-401/design.md
@@ -1,0 +1,201 @@
+## Context
+
+`PR Demo Test` mints a GitHub Actions OIDC token, deploys a Railway PR
+preview, then runs `cascade-test` against that preview. Setup begins
+with `packages/back/test/lib/setup.js` (~line 285–293) POSTing
+`{ token }` to `/api/auth/login/actions`, which calls
+`verifyActionsTokenFn({ token, audience: apiOrigin, allowedRepo:
+githubActionsOidcRepo })` in `packages/back/routes/auth.js:784`. The
+verifier (in `packages/back/routes/shared/github-actions-oidc.js`) uses
+`jsonwebtoken.verify` with the GitHub Actions JWKS, the configured
+issuer/audience/algorithm, and a hand-rolled post-verify check on the
+`repository` claim. On any failure, it resolves `null`; the route then
+returns 401 and `auth.js:790` logs a single opaque `logger.warn`.
+
+This shape made sense as long as Actions OIDC worked locally and was
+expected to work in preview. It does not: the cascade-test preview run
+gets HTTP 401 today, and the conversation history (see
+`.scratch/pr-demo-oidc-401-handoff.md`) records that every cheap
+hypothesis — `RAILWAY_*` variables wrong, route not registered, ahem
+trailing-slash audience, JWKS network failure, repo claim mismatch — has
+been at most partially refuted. We cannot narrow further without
+observability.
+
+The previewbase and PR-preview environment vars have already been
+confirmed (`API_URL` set, `PREVIEW_ENV=true`, `GITHUB_ACTIONS_OIDC_REPO`
+set; the 401 — rather than 404 — proves the route is registered) so the
+remaining unknown is strictly inside `verifyActionsToken`'s decision
+branches.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Emit one structured log line per `/api/auth/login/actions` rejection
+  that names *which* check failed and includes the unverified claims +
+  expected values, so the next Railway log entry resolves the bug
+  without another guess-and-deploy cycle.
+- Apply the targeted root-cause fix indicated by the first post-deploy
+  log, in the same change, so the diagnose → identify → fix arc lands
+  together.
+- Preserve test-double ergonomics: `verifyActionsTokenFn` injection in
+  `actions-oidc-login.js` continues to work without callers being
+  forced to pass a logger.
+
+**Non-Goals:**
+
+- Replacing `jsonwebtoken` or `jwks-rsa` with alternatives.
+- Auditing or restructuring the broader auth router. The change is
+  scoped to the Actions OIDC verifier and its one caller.
+- Building generalised "explain why a JWT failed" infrastructure. The
+  enumeration is closed and Actions-OIDC-specific.
+- Adding metrics, traces, or other observability beyond structured
+  `logger.warn`. The handoff goal is one diagnostic deploy.
+
+## Decisions
+
+### Decision 1: Use `jsonwebtoken.decode` to surface unverified claims
+
+When `jwt.verify` rejects a token, the error object does not include
+the claims that were checked. To know whether the audience or issuer or
+repository mismatched, we have to decode the token *without* verifying
+its signature. `jsonwebtoken.decode(token, { complete: true })` returns
+`{ header, payload }` and never throws on bad signatures.
+
+**Rationale:** The decoded claims are needed to make the log
+actionable. We never grant trust on the basis of decoded claims — they
+are logged for human eyes only, after `jwt.verify` has already
+rejected the token.
+
+**Alternative considered:** Re-implementing each check manually before
+calling `jwt.verify` (decode → compare `aud`, then call `verify`).
+Rejected because it duplicates `jsonwebtoken`'s own logic and risks
+divergence (e.g. `aud` accepts string or string array, `iss` string
+comparison, etc.).
+
+### Decision 2: Closed `reason` enumeration over free-text messages
+
+Each rejection emits one of four stable `reason` values:
+`verifier-input-missing`, `jwks-key-fetch-failed`,
+`signature-or-claim-verification-failed`, `repository-claim-mismatch`.
+Free-form message detail goes alongside in structured fields
+(`unverifiedClaims`, `jwtErrorName`, `jwtErrorMessage`, `observedRepo`,
+etc.).
+
+**Rationale:** The codebase already uses stable `reason` enums for
+handoff failures (see `pr-preview-auth-handoff` spec, requirement
+"Authority emits a stable `reason` string for each handoff failure").
+Consistency with that pattern lets future log-search and alert rules
+treat both flows the same way.
+
+**Alternative considered:** A single `logger.warn` per failure with
+all detail in one message string. Rejected because the four causes
+have meaningfully different remediations and we want greppable
+distinction.
+
+### Decision 3: `logger` is optional, defaulted to a no-op
+
+`verifyActionsToken` accepts `{ token, audience, allowedRepo, logger }`.
+When `logger` is omitted (or its `.warn` is not a function), no log
+is emitted and the function returns `null` exactly as before.
+
+**Rationale:** The cascade-test `actions-oidc-login.js` injects a
+stubbed `verifyActionsTokenFn` and never exercises the real verifier.
+A required `logger` argument would either force every test fixture to
+pass one or break inadvertently when call sites are added later.
+Keeping it optional preserves the test double's small surface and
+matches how `cascade-test` itself accepts an optional `logger`.
+
+**Alternative considered:** Always require `logger`; throw if missing.
+Rejected — strict at the cost of brittleness without payoff.
+
+### Decision 4: Drop the opaque caller-side warn at `auth.js:790`
+
+The current `logger.warn('Actions OIDC login rejected: invalid or
+unauthorized token')` at the route level becomes redundant once the
+verifier emits a structured warn on every rejection path. Keeping both
+would double-log and the older line carries no information beyond
+"something in the verifier returned null".
+
+**Rationale:** Single source of truth for the failure reason. The
+verifier is the only thing that knows *why* it rejected; the route
+just sees `payload == null`.
+
+**Trade-off:** If the verifier is ever called without a logger from
+this route, we'd lose the warn entirely on a 401. Mitigated by
+explicitly threading the route's logger through at the call site as
+part of this change, and by spec'ing the logger-pass as a
+requirement.
+
+### Decision 5: Apply the root-cause fix in the same change
+
+The handoff document anticipates that the diagnostic log will point at
+exactly one cause (most likely audience normalization). Rather than
+ship instrumentation alone and open a follow-up change, this change
+includes a task to apply the fix once the log is read. If the log
+points at a class of fix we already understand (audience trim, repo
+claim sanity, JWKS connectivity), it lands here. If it points at
+something larger (e.g. a `jsonwebtoken` bug), this change still ships
+the instrumentation and the broader fix moves to a new change.
+
+**Rationale:** Avoids the overhead of a separate spec round-trip for a
+likely one-line fix. The diagnostic spec'd here stands on its own
+value (future debugging) even if the fix never gets applied.
+
+**Trade-off:** The change isn't fully predictable until the diagnostic
+runs. Mitigated by the task list explicitly gating the fix on the log
+output, and by keeping the proposal honest that the eventual fix is
+TBD until observation.
+
+## Risks / Trade-offs
+
+- **Risk: log leaks PII via the decoded claims.** GitHub Actions OIDC
+  tokens contain `sub`, `iss`, `aud`, `repository`, `repository_owner`,
+  `ref`, `run_id`, etc. — no user PII, but they do identify the repo
+  and workflow run. → Mitigation: this is the same data already in the
+  GitHub Actions log for the same run, and the Railway log is
+  operator-only. The log line whitelists fields explicitly rather than
+  dumping the whole payload, so future additions to the OIDC claim set
+  don't surprise us.
+- **Risk: noisy log on legitimate retries.** A misconfigured external
+  actor hammering `/api/auth/login/actions` would now emit one warn per
+  rejection instead of the older opaque one. → Mitigation: warn-level,
+  not error; cardinality is the same as before (one log per rejected
+  request); the route is gated on `isPreviewEnv` so production never
+  registers it.
+- **Trade-off: more code on a verifier that was four lines.** The
+  function grows by ~30 lines. → The complexity is in the logging,
+  not the verification — the security-relevant `jwt.verify` call and
+  its options are unchanged.
+
+## Migration Plan
+
+1. Land the instrumentation + spec on master.
+2. Rebase `restyle-settings-sliders` (the open PR's branch) onto master
+   so the Railway PR preview rebuilds with the new code.
+3. Force-with-lease push the rebased branch.
+4. Wait for Railway to redeploy the PR preview; retrigger `PR Demo Test`
+   (`gh run rerun --failed <run-id>` or push an empty commit).
+5. Read the Railway log entry for the new `verifyActionsToken` warn.
+6. Apply the indicated fix in a follow-up commit on master, repeat the
+   rebase, and re-verify.
+
+**Rollback:** If the instrumentation itself causes a regression (e.g.
+`jsonwebtoken.decode` throwing on malformed input), revert the one
+commit on master; the cascade-test and route behaviour falls back to
+the opaque-401 state we're in today.
+
+## Open Questions
+
+- **What does the first log say?** Cannot be answered until step 4 of
+  the migration plan. Hypotheses ranked in the proposal: (1) audience
+  string mismatch, (2) JWKS/network, (3) repo claim. The change ships
+  regardless of which one fires; the corresponding fix is the dependent
+  task.
+- **Does the eventual fix require a workflow-side change?** If the
+  audience needs trailing-slash normalization, that can be done either
+  in the workflow (`audience=${PREVIEW_URL%/}`) or in the backend
+  (`audience: apiOrigin.replace(/\/$/, '')`). Preferring backend
+  normalization keeps the workflow simple and matches the rest of the
+  config (frontend reads URLs through `fomoplayer_shared/config`).
+  Decision deferred until the log confirms the cause.

--- a/openspec/changes/diagnose-pr-demo-actions-oidc-401/proposal.md
+++ b/openspec/changes/diagnose-pr-demo-actions-oidc-401/proposal.md
@@ -1,0 +1,104 @@
+## Why
+
+The `PR Demo Test` workflow successfully deploys a Railway PR preview and
+mints a GitHub Actions OIDC token, but cascade-test's remote-preview login
+against `/api/auth/login/actions` is rejected with HTTP 401 — `Invalid or
+unauthorized Actions token`. The current backend implementation collapses
+six independent failure modes (JWKS fetch error, signature mismatch,
+expired token, issuer mismatch, audience mismatch, algorithm mismatch,
+repository-claim mismatch) into a single opaque `logger.warn` that says
+only "invalid or unauthorized token", so neither the Railway log nor the
+GitHub Actions log identifies which check fired. Without that signal we
+cannot move past the 401 — every hypothesis (trailing slash in audience,
+JWKS network failure, wrong `repository` claim, etc.) costs a full
+build-deploy-rerun cycle to disprove.
+
+We need the backend to tell us exactly which check failed on the next
+attempt, then we can ship the targeted fix and unblock the demo workflow.
+
+## What Changes
+
+- `packages/back/routes/shared/github-actions-oidc.js`:
+  `verifyActionsToken` accepts an optional `logger` argument. On every
+  rejection path it emits one structured `logger.warn` with a stable
+  `reason` enum value plus the diagnostic context needed to identify the
+  cause:
+  - `jwks-key-fetch-failed` — JWKS client error before signature
+    verification (includes `kid` from the unverified header and the
+    underlying error message).
+  - `signature-or-claim-verification-failed` — `jwt.verify` rejected the
+    token. Includes the decoded *unverified* claims (`iss`, `aud`, `sub`,
+    `repository`, `exp`, `alg`) so audience/issuer/exp mismatches are
+    obvious from the log line, plus the `jsonwebtoken` error name (e.g.
+    `JsonWebTokenError`, `TokenExpiredError`) and message.
+  - `repository-claim-mismatch` — signature verified but `payload.repository`
+    did not equal `allowedRepo`. Logs the observed vs. expected repo.
+  - `verifier-input-missing` — at least one of `token`, `audience`, or
+    `allowedRepo` was falsy at call time. Logs which one(s).
+
+  Each warning also includes `expectedAudience`, `expectedRepo`, and
+  `issuer = GITHUB_ACTIONS_ISSUER` so the operator can compare expected
+  vs. observed claims in a single line.
+
+  When no `logger` is passed, the function preserves today's behaviour
+  (silent rejection) so existing call sites and tests are unaffected
+  until they opt in.
+
+- `packages/back/routes/auth.js` `/login/actions` route: pass the request
+  logger into `verifyActionsTokenFn`. Drop the existing line-790
+  `logger.warn('Actions OIDC login rejected: invalid or unauthorized
+  token')` — the verifier's structured warn replaces it.
+
+- After deploying the instrumentation to the Railway PR preview and
+  reading the Railway log on the next `PR Demo Test` run, apply the
+  targeted fix indicated by the `reason` and observed claims (most
+  likely audience-string normalization between the workflow's
+  `audience=${PREVIEW_URL}` and the backend's `apiOrigin = new
+  URL(apiURL).origin`, but the diagnostic could implicate JWKS or
+  repository claim instead). The fix lands in the same change so the
+  full diagnose → identify → fix arc is captured together.
+
+- Cascade-tests in `packages/back/test/tests/users/auth/actions-oidc-login.js`:
+  add a case asserting that when `verifyActionsTokenFn` returns null and
+  the request supplied a logger via the standard middleware, the
+  rejection path does not emit the now-removed opaque "invalid or
+  unauthorized token" warn (negative assertion against the old log
+  string). Add a unit-level cascade-test for `verifyActionsToken` itself
+  that exercises each failure path against a fake `logger` and asserts
+  the structured `reason` emitted.
+
+## Capabilities
+
+### New Capabilities
+
+- `actions-oidc-login`: GitHub Actions OIDC bot-login flow that lets
+  `cascade-test` (running inside `PR Demo Test`) exchange a workflow OIDC
+  token for a session on the PR preview backend. Covers the
+  diagnostic-logging contract introduced by this change.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- **Code**: `packages/back/routes/shared/github-actions-oidc.js` gains
+  ~30 lines (decode-unverified path, four log call sites). `auth.js`
+  changes one line at the route call site.
+- **Tests**: extend `actions-oidc-login.js` with new cases; add a unit
+  cascade-test for the verifier's logging contract.
+- **Docs**: no new doc file. The structured `reason` enumeration is
+  documented in this change's `design.md` and surfaced in code via the
+  function's behaviour.
+- **APIs**: no API surface change. `/api/auth/login/actions` request
+  and response shapes are unchanged. The only externally observable
+  change is the contents of the backend log.
+- **Workflow**: no `.github/workflows/pr-demo.yml` changes are required
+  for the diagnostic step. If the eventual root-cause fix is a workflow
+  change (e.g. audience normalization on the GitHub side), this change
+  documents it; otherwise the workflow stays as-is.
+- **Risk**: low. The instrumentation is purely additive on the
+  unverified path (uses `jsonwebtoken.decode`, which never executes
+  signature verification). The targeted fix is constrained to one of
+  three small surfaces (audience string, JWKS fetch, repo claim) and
+  the change is gated on observing the diagnostic first.

--- a/openspec/changes/diagnose-pr-demo-actions-oidc-401/specs/actions-oidc-login/spec.md
+++ b/openspec/changes/diagnose-pr-demo-actions-oidc-401/specs/actions-oidc-login/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Actions OIDC verifier MUST emit a structured `reason` warn on every rejection
+
+`verifyActionsToken` MUST emit exactly one `logger.warn` per rejection
+path when a `logger` is supplied, with a `reason` field drawn from the
+closed enumeration `verifier-input-missing`, `jwks-key-fetch-failed`,
+`signature-or-claim-verification-failed`, or `repository-claim-mismatch`.
+The log MUST include `expectedAudience`, `expectedRepo`, and
+`issuer = 'https://token.actions.githubusercontent.com'` so the operator
+can compare expected against observed values without consulting the
+calling code. When `logger` is omitted or its `.warn` is not a function,
+the verifier MUST NOT throw and MUST preserve today's silent-rejection
+behaviour.
+
+#### Scenario: Missing input is logged as verifier-input-missing
+
+- **WHEN** `verifyActionsToken` is called with `token`, `audience`, or
+  `allowedRepo` falsy and a logger is supplied
+- **THEN** the verifier resolves `null` and `logger.warn` is called
+  exactly once with `reason: 'verifier-input-missing'` and a
+  `missing` array enumerating which inputs were absent
+
+#### Scenario: JWKS signing-key lookup failure is logged as jwks-key-fetch-failed
+
+- **WHEN** the JWKS client errors before signature verification (e.g.
+  network failure, unknown `kid`)
+- **THEN** the verifier resolves `null` and `logger.warn` is called
+  exactly once with `reason: 'jwks-key-fetch-failed'`, the `kid` from
+  the unverified header (or `null` if absent), and the underlying
+  error name and message
+
+#### Scenario: Signature or claim mismatch is logged with unverified claims
+
+- **WHEN** `jwt.verify` rejects the token (signature, audience,
+  issuer, algorithm, or expiry failure)
+- **THEN** the verifier resolves `null` and `logger.warn` is called
+  exactly once with `reason: 'signature-or-claim-verification-failed'`,
+  the `jsonwebtoken` error `name` and `message`, and an
+  `unverifiedClaims` object containing the token's decoded `iss`,
+  `aud`, `sub`, `repository`, `exp`, and unverified header `alg`
+
+#### Scenario: Repository claim mismatch is logged after signature verification
+
+- **WHEN** `jwt.verify` accepts the token but `payload.repository !==
+  allowedRepo`
+- **THEN** the verifier resolves `null` and `logger.warn` is called
+  exactly once with `reason: 'repository-claim-mismatch'`, the
+  observed `repository` value, and the configured `expectedRepo`
+
+#### Scenario: No logger supplied means silent rejection
+
+- **WHEN** `verifyActionsToken` is called without a `logger`, or with a
+  `logger` whose `warn` property is not a function, and verification
+  fails
+- **THEN** the verifier resolves `null` and no exception is thrown
+
+### Requirement: `/api/auth/login/actions` MUST pass its logger into `verifyActionsTokenFn`
+
+`POST /api/auth/login/actions` MUST invoke `verifyActionsTokenFn` with the request's logger and MUST NOT emit a separate opaque "invalid or unauthorized token" warn at the route level, so the verifier's structured warn is the single source of truth for rejection diagnostics.
+
+#### Scenario: Rejection from the verifier produces exactly the verifier's structured warn
+
+- **WHEN** `verifyActionsTokenFn` resolves `null` for a request to
+  `POST /api/auth/login/actions`
+- **THEN** the route responds with HTTP 401 and the *only* `warn`
+  attributable to this request comes from the verifier's structured
+  log (i.e. no `warn` containing the literal string `'invalid or
+  unauthorized token'` is emitted by the route)
+
+#### Scenario: Logger is threaded into the verifier on every request
+
+- **WHEN** a request arrives at `POST /api/auth/login/actions` with a
+  body containing `{ token: '...' }`
+- **THEN** `verifyActionsTokenFn` is invoked with a `logger` argument
+  whose `.warn` is a function (the same logger used elsewhere by the
+  route)

--- a/openspec/changes/diagnose-pr-demo-actions-oidc-401/tasks.md
+++ b/openspec/changes/diagnose-pr-demo-actions-oidc-401/tasks.md
@@ -1,0 +1,192 @@
+## 1. Pre-flight: confirm the call graph and existing test fixtures
+
+- [x] 1.1 Re-read `packages/back/routes/shared/github-actions-oidc.js`
+      end-to-end and confirm `verifyActionsToken`'s four rejection
+      paths map 1:1 to the `reason` enumeration in
+      `specs/actions-oidc-login/spec.md`: input-missing,
+      JWKS-key-fetch-failed, sig-or-claim-verification-failed,
+      repository-claim-mismatch.
+- [x] 1.2 Re-read `packages/back/routes/auth.js` ~line 778–805 and
+      confirm the route has a `logger` in scope to thread into
+      `verifyActionsTokenFn`.
+- [x] 1.3 Re-read `packages/back/test/tests/users/auth/actions-oidc-login.js`
+      and confirm the test injects `verifyActionsTokenFn` as a stub,
+      so the new logger-pass requirement can be asserted via the
+      injected stub's call args without invoking the real verifier.
+- [x] 1.4 Grep `packages/back/` for `verifyActionsToken(` (production
+      call sites) and `verifyActionsTokenFn(` (test sites) to make
+      sure no other callers exist that would also need updating.
+
+## 2. Instrument the verifier
+
+- [x] 2.1 In `packages/back/routes/shared/github-actions-oidc.js`,
+      change `verifyActionsToken` to accept `{ token, audience,
+      allowedRepo, logger }`. Implement a `safeWarn(reason, detail)`
+      helper that no-ops when `logger?.warn` is not a function,
+      otherwise calls `logger.warn({ reason, expectedAudience:
+      audience, expectedRepo: allowedRepo, issuer:
+      GITHUB_ACTIONS_ISSUER, ...detail })`.
+- [x] 2.2 At the top of the function, if any of `token`, `audience`,
+      `allowedRepo` is falsy, call `safeWarn('verifier-input-missing',
+      { missing: [<names of falsy inputs>] })` and resolve `null`.
+- [x] 2.3 Wrap `getSigningKey` so that when `jwksClient.getSigningKey`
+      errors, the error path emits `safeWarn('jwks-key-fetch-failed',
+      { kid: header?.kid ?? null, errorName: err.name, errorMessage:
+      err.message })` before passing the error through to
+      `jwt.verify`'s callback. This is the only way to distinguish a
+      JWKS network error from a signature mismatch from the warn,
+      because `jwt.verify` collapses both into a generic verify
+      error.
+- [x] 2.4 In `jwt.verify`'s callback, when `err || !payload || typeof
+      payload !== 'object'` and the upstream warn from step 2.3
+      hasn't already fired (i.e. err.name is not the
+      `jwks-key-fetch-failed` sentinel), call
+      `safeWarn('signature-or-claim-verification-failed', {
+      jwtErrorName: err?.name ?? null, jwtErrorMessage: err?.message
+      ?? null, unverifiedClaims: extractUnverifiedClaims(token) })`
+      and resolve `null`.
+- [x] 2.5 Implement `extractUnverifiedClaims(token)` using
+      `jsonwebtoken.decode(token, { complete: true })`. Return `{ iss,
+      aud, sub, repository, exp, alg }` whitelisted from the decoded
+      payload/header. Wrap in a try/catch and return `null` if decode
+      throws (malformed input shouldn't break the warn).
+- [x] 2.6 After `jwt.verify` accepts the token, when `payload.repository
+      !== allowedRepo`, call `safeWarn('repository-claim-mismatch', {
+      observedRepo: payload.repository ?? null })` and resolve `null`.
+- [x] 2.7 Confirm the `jwt.verify` options object
+      (`{ issuer: GITHUB_ACTIONS_ISSUER, audience, algorithms:
+      ['RS256'] }`) is unchanged — the security-relevant verification
+      is not being touched.
+
+## 3. Wire the route through
+
+- [x] 3.1 In `packages/back/routes/auth.js` at the `/login/actions`
+      route, pass `logger` into the `verifyActionsTokenFn` call:
+      `verifyActionsTokenFn({ token, audience: apiOrigin,
+      allowedRepo: githubActionsOidcRepo, logger })`.
+- [x] 3.2 Delete the line `logger.warn('Actions OIDC login rejected:
+      invalid or unauthorized token')` at ~line 790. The verifier
+      now owns the warn.
+
+## 4. Update and extend cascade-tests
+
+- [x] 4.1 In `packages/back/test/tests/users/auth/actions-oidc-login.js`,
+      extend the existing "verifyActionsToken is called with apiOrigin
+      as audience and configured repo" test so its `capturedArgs`
+      assertion also checks `capturedArgs.logger` is the request
+      logger (i.e. an object with a `.warn` function).
+- [x] 4.2 Add a new test case "POST /login/actions — verifier rejection
+      does not emit the old opaque warn at the route": stub
+      `verifyActionsTokenFn` to resolve `null`, attach a recording
+      logger to the app, request the route, assert the response is
+      401 and the recording logger has no `warn` entry containing
+      the literal string `invalid or unauthorized`.
+- [x] 4.3 Add a sibling cascade-test file
+      `packages/back/test/tests/users/auth/actions-oidc-verifier.js`
+      that exercises `verifyActionsToken` directly (the real one,
+      not the stub). For each of the five spec scenarios:
+      - input-missing
+      - jwks-key-fetch-failed: inject a fake `jwksClient` via the
+        new `createVerifyActionsToken({ jwksClient })` factory whose
+        `getSigningKey` calls back with an error (replaces the
+        proxyquire/nock approach since neither is a project dep)
+      - signature-or-claim-verification-failed: mint a token signed
+        with a *different* key (or hand-craft a JWT with deliberately
+        wrong audience) and inject a JWKS client returning a valid
+        public key for the real issuer so `jwt.verify` rejects on
+        audience/sig
+      - repository-claim-mismatch: mint a token whose signature
+        verifies but `repository` is the wrong value (test private
+        key + matching public key in injected JWKS client)
+      - no-logger silent rejection: same input as the previous case
+        but call without a `logger` and assert no throw + null
+        result.
+- [x] 4.4 Run `yarn workspace fomoplayer_back cascade-test
+      --regex 'actions-oidc'` (or the project's standard cascade-test
+      invocation) and confirm all cases pass. Verified all 17 cases
+      pass (and the full `users/auth/` suite of 177 tests stays
+      green).
+
+## 5. Land the diagnostic and observe
+
+- [x] 5.1 Commit steps 2–4 to master as a single change (per the
+      project's commit policy that backend + tests stay together).
+      Per user request, landed on side branch
+      `diagnose-pr-demo-actions-oidc-401` (commit `6e5b1c36`) and
+      pushed to origin — PR to be opened by user, then merged to
+      master before the next steps. Original migration plan
+      (commit directly to master) was preserved as a single
+      bundled commit.
+- [ ] 5.2 Rebase the `restyle-settings-sliders` branch (or whichever
+      branch currently has the failing PR demo) onto master and
+      force-with-lease push, so Railway redeploys the PR preview
+      with the diagnostic.
+- [ ] 5.3 Wait for the Railway PR preview to finish redeploying.
+      Then retrigger `PR Demo Test` on the PR (either
+      `gh run rerun --failed <run-id>` against the most recent run
+      or push an empty commit).
+- [ ] 5.4 Read the Railway log for the new `verifyActionsToken` warn
+      attributable to the cascade-test request. Capture the
+      structured `reason` value and any associated fields in
+      `notes.md` (create the file if it doesn't exist).
+
+## 6. Apply the targeted fix
+
+- [ ] 6.1 Based on the observed `reason` and the diagnostic fields,
+      identify the root cause:
+      - `signature-or-claim-verification-failed` with `aud` mismatch:
+        normalize trailing slashes on backend `apiOrigin` (or
+        whichever side has the discrepancy) and document the
+        normalization in `routes/auth.js` near the verifier call.
+      - `jwks-key-fetch-failed`: investigate Railway's outbound
+        connectivity to `token.actions.githubusercontent.com`;
+        possibly add a retry or surface a more specific error to
+        the workflow.
+      - `repository-claim-mismatch`: confirm
+        `GITHUB_ACTIONS_OIDC_REPO` matches the actual repo
+        (`owner/name`, case-sensitive); fix the env var or the
+        comparison.
+      - `verifier-input-missing`: trace which input is undefined
+        and fix at the source.
+- [ ] 6.2 Implement the fix in the same change. Add a regression
+      cascade-test under
+      `packages/back/test/tests/users/auth/actions-oidc-login.js`
+      or the new verifier file that exercises the specific cause
+      (e.g. audience-with-trailing-slash matches audience-without,
+      or a known-bad repo string is rejected).
+- [ ] 6.3 Commit the fix, rebase the PR branch on master again,
+      force-with-lease push, and confirm `PR Demo Test` now reaches
+      the cascade-test execution phase (i.e. the 401 is gone). The
+      cascade-test itself passing all the way through is the
+      success signal for the broader PR-demo goal, but is out of
+      scope for the spec assertions of this change.
+
+## 7. Verify and clean up
+
+- [ ] 7.1 Confirm the new and existing cascade-tests in the `users/auth/`
+      suite all pass: at minimum
+      `actions-oidc-login.js`, the new `actions-oidc-verifier.js`,
+      and the existing handoff-related suites that share the
+      `createAuthRouter` factory (`handoff-login-return.js`,
+      `handoff-login-signup-policy.js`, `config-handoff-fail-fast.js`,
+      `config-preview-access.js`, `api-key-exchange.js`).
+- [ ] 7.2 Verify with the user that the `PR Demo Test` workflow on the
+      open PR now reaches video upload (the demo-video artifact
+      named `demo-video-pr-<n>` is attached to the workflow run).
+      This is the original goal stated in the handoff document.
+- [ ] 7.3 Update `notes.md` with the final observed `reason`, the fix
+      applied, and any surprises encountered for the archive step.
+- [ ] 7.4 If the slider restyle PR is no longer needed as a test
+      vehicle once the workflow is green, coordinate with the user
+      on whether to merge, close, or keep it open for the demo
+      recording artifact.
+
+## 8. Backlog hygiene
+
+- [ ] 8.1 No backlog symlink to move (this change came from a direct
+      user request via `.scratch/pr-demo-oidc-401-handoff.md`, not a
+      tracked backlog item). Confirm and skip.
+- [ ] 8.2 If anything surprising surfaces during implementation
+      (unexpected verifier inputs, additional rejection paths in
+      `jsonwebtoken`, JWKS caching behaviour, etc.) capture it in
+      the change's `notes.md` for the archive step.

--- a/openspec/changes/restyle-settings-sliders/.openspec.yaml
+++ b/openspec/changes/restyle-settings-sliders/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-19

--- a/openspec/changes/restyle-settings-sliders/design.md
+++ b/openspec/changes/restyle-settings-sliders/design.md
@@ -141,26 +141,31 @@ file uses the existing `cascade-test` framework already used by
 
 ### 5. PR-demo wiring
 
-**Choice:** the PR opened from this branch will:
+**Choice:** the PR opened from this branch will embed a fenced block
+of the exact form `.github/workflows/pr-demo.yml` expects in its body:
 
-- Carry the GitHub label `demo-test` (must be applied by a maintainer
-  per the workflow's `pull_request: types: [labeled, synchronize]`
-  trigger).
-- Embed in the PR body a fenced block of the exact form expected by
-  `.github/workflows/pr-demo.yml`:
+```demo-test
+test/browser/settings-slider.js
+```
 
-  ```demo-test
-  test/browser/settings-slider.js
-  ```
+The workflow triggers on `pull_request: types: [opened, edited,
+synchronize, reopened]` and gates the `demo-test` job on (a) the body
+containing a fenced ` ```demo-test ` block and (b) the PR
+`author_association` being `OWNER` or `COLLABORATOR`. No GitHub label
+is needed; the fenced block is the sole opt-in signal. The workflow
+reads the path relative to `packages/back/` and runs `cascade-test`
+against the Railway preview deployment, uploading the recorded video
+as `demo-video-pr-<n>` and commenting on the PR with a link to the
+run.
 
-  The workflow reads the path relative to `packages/back/` and runs
-  `cascade-test` against the Railway preview deployment, uploading
-  the recorded video as `demo-video-pr-<n>` and commenting on the
-  PR with a link to the run.
-
-**Rationale:** mirrors the contract already documented inline in the
-workflow file. We are exercising the existing pipeline rather than
-inventing a new one.
+**Rationale:** an earlier draft of this change used a `demo-test`
+label as the trigger, paired with an auto-label workflow that
+applied it from the body. That broke against GitHub's safety rule
+that `GITHUB_TOKEN`-emitted events do not propagate to other
+workflows, so the labelled event never reached `pr-demo.yml`. The
+fenced block + author-association gate sidesteps the propagation
+issue and keeps the cheap maintainer protection against drive-by PRs
+spending Railway preview minutes.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/restyle-settings-sliders/design.md
+++ b/openspec/changes/restyle-settings-sliders/design.md
@@ -1,0 +1,205 @@
+## Context
+
+The settings page (`/settings`) exposes a stack of score-weight inputs
+rendered by `Settings.js#renderWeightInputs`. Each one is an
+`<input type="range">` whose track and thumb today come from the
+single `input[type='range']` rule in `packages/front/src/App.css`. The
+existing rule:
+
+- Sets the bar height to `1rem`, fills it with a `#222` background
+  with a `linear-gradient(var(--fp-brand-primary), …)` painted across
+  the leading portion via `background-size`.
+- Renders a `1rem × 1rem`, rounded-`0.25rem` **white** thumb with a
+  faint dark shadow.
+
+The mockup the maintainer shared (square aspect ratio, dark backdrop)
+shows a different visual language:
+
+- A very thin horizontal track (looks like a 1–2 px hairline) sitting
+  on a dark surface.
+- A small circular thumb filled with brand magenta and ringed by a
+  white halo. No square corners. No drop shadow.
+
+The change is purely a CSS rewrite (no React or DOM changes). It is
+also a convenient candidate for proving the recently-added `demo-test`
+PR workflow, which already exists at `.github/workflows/pr-demo.yml`
+and runs against a Railway preview when a PR is labelled `demo-test`
+and contains a ` ```demo-test ` block in its body.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Replace the slider visual with a thin track + circular brand thumb
+  that matches the mockup, sourcing colours from the existing
+  `--fp-brand-primary*` tokens so the theme contract is preserved.
+- Cover WebKit (Chrome/Safari) and Gecko (Firefox) pseudo-elements so
+  the new look is consistent across the browsers the front-end
+  targets.
+- Keep the React/JSX call sites (`Settings.js`) untouched apart from
+  removing inline styles that would fight the new CSS.
+- Ship a committed `cascade-test` browser test that opens
+  `/settings`, drags a slider thumb, and asserts the numeric value
+  and the filled-track width respond — so the `demo-test` workflow
+  picks it up and produces a recorded video/trace artifact.
+
+**Non-Goals:**
+
+- Changing the score-weight model, defaults, min/max, or step values.
+- Restyling other range inputs outside the settings page beyond what
+  the global `input[type='range']` rule already governs (the rule is
+  global today and stays global; we do not introduce per-page
+  variants).
+- Modifying the `pr-demo.yml` workflow itself — we only consume it.
+- Introducing a new component library or replacing the native input
+  element. The native `<input type="range">` stays.
+
+## Decisions
+
+### 1. Keep the native `<input type="range">`, restyle via CSS only
+
+**Choice:** Edit the existing global `input[type='range']` rule (and
+its pseudo-element children) in `packages/front/src/App.css`. No JSX
+changes beyond pruning inline styles that conflict.
+
+**Alternatives considered:**
+
+- *Replace with a React slider component (`rc-slider`, Radix, etc.)* —
+  Rejected. Adds a dependency, forces a rewrite of
+  `renderWeightInputs`, and risks accessibility regressions on a
+  visual-only ticket.
+- *Per-page `.settings-slider` class* — Rejected. The global rule
+  already paints every range input on the site (only the settings
+  page renders any today). A page-scoped class adds specificity churn
+  without changing the rendered surface.
+
+**Rationale:** native inputs already give us keyboard accessibility,
+ARIA, and form semantics for free. The mockup is a pure paint job.
+
+### 2. Track + thumb geometry
+
+**Choice:**
+
+- Track height: `2px` (hairline) painted on a transparent backdrop so
+  the surrounding dark UI shows through. The leading portion painted
+  in `var(--fp-brand-primary)` via `background-image` +
+  `background-size` (the existing technique — keeps JS unchanged).
+- Thumb: circular (`border-radius: 50%`), `14px × 14px`,
+  `background: var(--fp-brand-primary)`, `border: 2px solid #fff`
+  to produce the white halo seen in the mockup. No drop shadow.
+- Container height stays `1rem` so the thumb has room to render
+  without clipping; the visible track is centred via
+  `background-position: center` and a `2px` gradient stripe.
+
+**Alternatives considered:**
+
+- *1 px track* — Rejected. Renders inconsistently across DPI and at
+  some zooms disappears entirely. 2 px is the minimum that survives
+  fractional scaling.
+- *Solid grey track instead of transparent* — Rejected. The mockup
+  shows the dark surface bleeding through; a hard-coded track colour
+  would clash on lighter surfaces (we do not have a guaranteed
+  background colour for every page that hosts a slider).
+
+### 3. Firefox parity
+
+**Choice:** add explicit `::-moz-range-track` and `::-moz-range-thumb`
+rules mirroring the WebKit pseudo-elements. The track-fill technique
+(painting the background gradient on the input itself) works in
+Firefox because Firefox lets the input's own `background` show through
+the track when the track itself is `background: transparent`.
+
+**Alternatives considered:**
+
+- *Lean on `accent-color` only* — Rejected. `accent-color` recolors
+  the thumb and the filled portion, but does not let us change the
+  thumb shape or add the white halo.
+
+### 4. Cascade-test as the demo vehicle
+
+**Choice:** add `packages/back/test/browser/settings-slider.js`. The
+file uses the existing `cascade-test` framework already used by
+`test/browser/settings.js` and friends. It will:
+
+1. Navigate to `/settings` (the score-weights section).
+2. Wait for the score-weight slider inputs to render.
+3. Read the initial numeric value from the sibling number input.
+4. Drag the first slider's thumb with Playwright's mouse API and
+   keyboard arrows so the motion is visible on the recording.
+5. Assert the sibling number input updates and that the computed
+   `background-size` of the slider element changes (proving the
+   filled portion responded).
+
+**Alternatives considered:**
+
+- *Mocha + jsdom unit test* — Rejected. The point of this exercise is
+  to drive the `demo-test` workflow, which expects a Playwright-driven
+  cascade-test producing a video.
+- *Synthetic input event without dragging* — Rejected. The recording
+  would be a 0-frame change. The drag-with-arrows path is slower but
+  produces a meaningful video.
+
+### 5. PR-demo wiring
+
+**Choice:** the PR opened from this branch will:
+
+- Carry the GitHub label `demo-test` (must be applied by a maintainer
+  per the workflow's `pull_request: types: [labeled, synchronize]`
+  trigger).
+- Embed in the PR body a fenced block of the exact form expected by
+  `.github/workflows/pr-demo.yml`:
+
+  ```demo-test
+  test/browser/settings-slider.js
+  ```
+
+  The workflow reads the path relative to `packages/back/` and runs
+  `cascade-test` against the Railway preview deployment, uploading
+  the recorded video as `demo-video-pr-<n>` and commenting on the
+  PR with a link to the run.
+
+**Rationale:** mirrors the contract already documented inline in the
+workflow file. We are exercising the existing pipeline rather than
+inventing a new one.
+
+## Risks / Trade-offs
+
+- **Risk:** the hairline track is visually fragile on light
+  backgrounds (the score-weights section sits on a dark surface
+  today, so this is currently OK, but future placements of the slider
+  could land on white). → **Mitigation:** the requirement only
+  constrains the **settings** placement, and we document the dark-
+  backdrop assumption in the spec scenario. A future change can layer
+  a per-context track colour if/when a slider appears on a light
+  surface.
+
+- **Risk:** Firefox's track-fill technique is implemented by reusing
+  the input's `background`. Some Firefox versions render the thumb
+  area as a clipped rectangle, briefly exposing the input background
+  through the thumb. → **Mitigation:** the thumb's solid brand fill
+  plus white border masks this completely; no `box-shadow` tricks
+  required.
+
+- **Risk:** `demo-test` workflow contractual drift (someone could
+  rename the label or the fenced-block tag). → **Mitigation:** the
+  new `pr-demo-test-workflow` spec encodes the contract so future
+  edits to the workflow flag it as a spec-level change.
+
+- **Trade-off:** keeping the global selector means the new look will
+  apply anywhere on the site that hosts an `<input type="range">`.
+  Today that is only the settings page; this is the cheapest design
+  and we accept it.
+
+## Migration Plan
+
+- Pure-CSS change ships in the same commit as the test. No data
+  migration, no flag, no rollout staging. Revert is a single-file
+  `git revert`.
+- The cascade-test file is new — running it requires the Railway
+  preview to be live, but it is only invoked by the `pr-demo.yml`
+  workflow when the `demo-test` label is present, so it does not
+  block CI on PRs that opt out.
+
+## Open Questions
+
+_None._

--- a/openspec/changes/restyle-settings-sliders/proposal.md
+++ b/openspec/changes/restyle-settings-sliders/proposal.md
@@ -1,0 +1,65 @@
+## Why
+
+The current settings-page sliders (the score-weight inputs rendered by
+`renderWeightInputs` in `packages/front/src/Settings.js`) use a chunky
+square-thumb / progress-bar look that is heavy, dated, and visually loud
+relative to the rest of the settings UI. The desired look is a thin,
+unobtrusive horizontal track with a small circular brand-coloured thumb,
+matching the reference mockup the maintainer shared. Refreshing the
+slider also gives us an opportunity to exercise the `demo-test` PR
+workflow end-to-end so future visual-tweak PRs have a working template
+for shipping a recorded demo alongside the change.
+
+## What Changes
+
+- Restyle `input[type='range']` in `packages/front/src/App.css` so the
+  track renders as a thin dark line with a small circular thumb in
+  `var(--fp-brand-primary)` ringed in white, matching the mockup.
+- Cover the WebKit and Firefox (`::-moz-range-track`,
+  `::-moz-range-thumb`) pseudo-elements so the new look ships in every
+  browser the front-end targets.
+- Keep the filled-portion treatment (left of the thumb tinted brand)
+  driven by `background-size`, so the existing
+  `Settings.js#renderWeightInputs` JSX continues to work without React
+  changes — only the CSS contract changes.
+- Add a new cascade-test browser test that loads `/settings`, locates a
+  score-weight slider, drags its thumb, and asserts the value and
+  filled-track width respond, producing a Playwright video and trace
+  when run via the `demo-test` workflow.
+- Document the demo-test wiring in the PR body: the PR will carry the
+  `demo-test` label and embed a fenced ` ```demo-test ` block pointing
+  at the new test file so `.github/workflows/pr-demo.yml` picks it up
+  and uploads the recorded video as an artifact.
+
+## Capabilities
+
+### New Capabilities
+- `settings-slider-style`: visual contract for the `input[type='range']`
+  controls used on the settings page (track shape, thumb shape, brand
+  colour sourcing, and cross-browser coverage).
+- `pr-demo-test-workflow`: documents the contract the `pr-demo.yml`
+  GitHub workflow expects from a PR (label + fenced ` ```demo-test `
+  block in the body) and how a committed cascade-test file is wired up
+  so the workflow produces the recorded video artifact.
+
+### Modified Capabilities
+
+_None. The shared theme tokens already expose `--fp-brand-primary`; this
+change only consumes them in a new rule and does not change any spec-level
+requirement of `fomoplayer-theme-tokens`._
+
+## Impact
+
+- `packages/front/src/App.css`: the `input[type='range']` block and its
+  `::-webkit-slider-thumb` / `::-webkit-slider-runnable-track` rules
+  rewritten; new `::-moz-range-track` / `::-moz-range-thumb` rules
+  added.
+- `packages/front/src/Settings.js`: inline styles on the
+  `renderWeightInputs` `<input type="range">` audited so they do not
+  fight the new CSS (the `backgroundSize` driver stays).
+- `packages/back/test/browser/settings-slider.js`: new cascade-test
+  file exercising a settings slider end-to-end.
+- PR description: gains a ` ```demo-test ` fenced block pointing at
+  `test/browser/settings-slider.js` and the `demo-test` label so the
+  existing `pr-demo.yml` workflow runs it against the Railway preview.
+- No backend, no database, no API surface changes.

--- a/openspec/changes/restyle-settings-sliders/proposal.md
+++ b/openspec/changes/restyle-settings-sliders/proposal.md
@@ -26,10 +26,12 @@ for shipping a recorded demo alongside the change.
   score-weight slider, drags its thumb, and asserts the value and
   filled-track width respond, producing a Playwright video and trace
   when run via the `demo-test` workflow.
-- Document the demo-test wiring in the PR body: the PR will carry the
-  `demo-test` label and embed a fenced ` ```demo-test ` block pointing
-  at the new test file so `.github/workflows/pr-demo.yml` picks it up
-  and uploads the recorded video as an artifact.
+- Document the demo-test wiring in the PR body: the PR will embed a
+  fenced ` ```demo-test ` block pointing at the new test file so
+  `.github/workflows/pr-demo.yml` picks it up and uploads the
+  recorded video as an artifact. The workflow triggers on PR
+  open/edit/sync and gates on the fenced block plus the author's
+  `OWNER`/`COLLABORATOR` association; no label is required.
 
 ## Capabilities
 
@@ -38,9 +40,10 @@ for shipping a recorded demo alongside the change.
   controls used on the settings page (track shape, thumb shape, brand
   colour sourcing, and cross-browser coverage).
 - `pr-demo-test-workflow`: documents the contract the `pr-demo.yml`
-  GitHub workflow expects from a PR (label + fenced ` ```demo-test `
-  block in the body) and how a committed cascade-test file is wired up
-  so the workflow produces the recorded video artifact.
+  GitHub workflow expects from a PR (fenced ` ```demo-test ` block in
+  the body + trusted `author_association`) and how a committed
+  cascade-test file is wired up so the workflow produces the recorded
+  video artifact.
 
 ### Modified Capabilities
 
@@ -60,6 +63,7 @@ requirement of `fomoplayer-theme-tokens`._
 - `packages/back/test/browser/settings-slider.js`: new cascade-test
   file exercising a settings slider end-to-end.
 - PR description: gains a ` ```demo-test ` fenced block pointing at
-  `test/browser/settings-slider.js` and the `demo-test` label so the
-  existing `pr-demo.yml` workflow runs it against the Railway preview.
+  `test/browser/settings-slider.js`; the existing `pr-demo.yml`
+  workflow runs it against the Railway preview when the PR is opened
+  by an `OWNER`/`COLLABORATOR`.
 - No backend, no database, no API surface changes.

--- a/openspec/changes/restyle-settings-sliders/specs/pr-demo-test-workflow/spec.md
+++ b/openspec/changes/restyle-settings-sliders/specs/pr-demo-test-workflow/spec.md
@@ -1,36 +1,39 @@
 ## ADDED Requirements
 
-### Requirement: PRs opt into the demo recording workflow via a label and a fenced block
+### Requirement: Trusted PRs opt into the demo recording workflow via a fenced block
 
-A PR that wants `.github/workflows/pr-demo.yml` to run a committed cascade-test SHALL carry the GitHub label `demo-test` AND embed in its PR body a fenced code block tagged exactly `demo-test` whose single line is the path to a committed cascade-test file, relative to `packages/back/`. Both pieces MUST be present: the label is what triggers the workflow, and the fenced block is how the workflow discovers which test to run.
+A PR that wants `.github/workflows/pr-demo.yml` to run a committed cascade-test SHALL embed in its PR body a fenced code block tagged exactly `demo-test` whose single line is the path to a committed cascade-test file, relative to `packages/back/`. The workflow MUST only run when the PR author's `author_association` is `OWNER` or `COLLABORATOR`, so drive-by PRs cannot consume Railway preview minutes or GitHub Actions minutes on the maintainer's account. No GitHub label is required to trigger the workflow — the fenced block is the sole opt-in signal.
 
-#### Scenario: Workflow runs when the label and the fenced block are both present
+#### Scenario: Workflow runs when a trusted PR is opened with a fenced demo-test block
 
-- **WHEN** a maintainer applies the `demo-test` label to a pull request
-  whose body contains a fenced ` ```demo-test ` block naming a real
-  committed test path under `packages/back/test/browser/`
+- **WHEN** an `OWNER` or `COLLABORATOR` opens (or edits, reopens, or
+  pushes commits to) a pull request whose body contains a fenced
+  ` ```demo-test ` block naming a real committed test path under
+  `packages/back/test/browser/`
 - **THEN** the `pr-demo.yml` workflow's `demo-test` job runs, executes
   `npx cascade-test <path>` against the Railway preview URL, and
   uploads the recorded video as the `demo-video-pr-<number>` artifact.
 
-#### Scenario: Workflow fails fast if the fenced block is missing
+#### Scenario: Workflow is skipped when the PR has no fenced demo-test block
 
-- **WHEN** the `demo-test` label is applied to a PR whose body has no
-  ` ```demo-test ` fenced block
-- **THEN** the workflow step "Extract test file from PR body" fails the
-  job with the error `No \`\`\`demo-test\`\`\` block found in PR body`
-  and no test is executed.
+- **WHEN** a pull request is opened or edited and its body does not
+  contain a fenced ` ```demo-test ` block
+- **THEN** the `demo-test` job's `if:` guard evaluates to false and
+  the job is skipped without running any steps — no cascade-test
+  executes, no comment is posted.
+
+#### Scenario: Workflow is skipped when the PR author is not trusted
+
+- **WHEN** a contributor whose `author_association` is not `OWNER` or
+  `COLLABORATOR` opens a pull request that contains a fenced
+  ` ```demo-test ` block
+- **THEN** the `demo-test` job's `if:` guard evaluates to false and
+  the job is skipped — no Railway preview minutes or GitHub Actions
+  minutes are consumed on the maintainer's account.
 
 ### Requirement: The PR for this change ships a cascade-test file that drives the new slider
 
-This change SHALL ship a committed cascade-test file at
-`packages/back/test/browser/settings-slider.js` that opens the settings
-page, exercises the restyled score-weight slider end-to-end, and emits
-visible motion suitable for a Playwright video recording. The test MUST
-assert at least one observable change to a score-weight slider's
-reported value or filled-track width after a simulated user
-interaction, so a green run proves the slider is functional and the
-recording proves it visually.
+This change SHALL ship a committed cascade-test file at `packages/back/test/browser/settings-slider.js` that opens the settings page, exercises the restyled score-weight slider end-to-end, and emits visible motion suitable for a Playwright video recording. The test MUST assert at least one observable change to a score-weight slider's reported value or filled-track width after a simulated user interaction, so a green run proves the slider is functional and the recording proves it visually.
 
 #### Scenario: Demo test drags a settings slider and asserts the value moved
 
@@ -50,5 +53,5 @@ recording proves it visually.
 - **WHEN** the PR for this change is opened
 - **THEN** its body contains a fenced ` ```demo-test ` block whose
   sole content line is `test/browser/settings-slider.js`, and the PR
-  carries the `demo-test` GitHub label so the workflow runs against
-  the Railway preview deployment.
+  is opened by an `OWNER` or `COLLABORATOR` so the workflow runs
+  against the Railway preview deployment.

--- a/openspec/changes/restyle-settings-sliders/specs/pr-demo-test-workflow/spec.md
+++ b/openspec/changes/restyle-settings-sliders/specs/pr-demo-test-workflow/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: PRs opt into the demo recording workflow via a label and a fenced block
+
+A PR that wants `.github/workflows/pr-demo.yml` to run a committed cascade-test SHALL carry the GitHub label `demo-test` AND embed in its PR body a fenced code block tagged exactly `demo-test` whose single line is the path to a committed cascade-test file, relative to `packages/back/`. Both pieces MUST be present: the label is what triggers the workflow, and the fenced block is how the workflow discovers which test to run.
+
+#### Scenario: Workflow runs when the label and the fenced block are both present
+
+- **WHEN** a maintainer applies the `demo-test` label to a pull request
+  whose body contains a fenced ` ```demo-test ` block naming a real
+  committed test path under `packages/back/test/browser/`
+- **THEN** the `pr-demo.yml` workflow's `demo-test` job runs, executes
+  `npx cascade-test <path>` against the Railway preview URL, and
+  uploads the recorded video as the `demo-video-pr-<number>` artifact.
+
+#### Scenario: Workflow fails fast if the fenced block is missing
+
+- **WHEN** the `demo-test` label is applied to a PR whose body has no
+  ` ```demo-test ` fenced block
+- **THEN** the workflow step "Extract test file from PR body" fails the
+  job with the error `No \`\`\`demo-test\`\`\` block found in PR body`
+  and no test is executed.
+
+### Requirement: The PR for this change ships a cascade-test file that drives the new slider
+
+This change SHALL ship a committed cascade-test file at
+`packages/back/test/browser/settings-slider.js` that opens the settings
+page, exercises the restyled score-weight slider end-to-end, and emits
+visible motion suitable for a Playwright video recording. The test MUST
+assert at least one observable change to a score-weight slider's
+reported value or filled-track width after a simulated user
+interaction, so a green run proves the slider is functional and the
+recording proves it visually.
+
+#### Scenario: Demo test drags a settings slider and asserts the value moved
+
+- **WHEN** the cascade-test runner executes
+  `packages/back/test/browser/settings-slider.js` against a live
+  preview
+- **THEN** the test navigates to `/settings`, waits for the score-
+  weight slider inputs to render, captures the initial value of the
+  first score-weight slider, simulates user input on its thumb (mouse
+  drag and/or arrow-key presses with `keyboard.press`), and asserts
+  that the slider's reported `value` (or its sibling number input's
+  `value`) is different from the initial value when the interaction
+  completes.
+
+#### Scenario: The PR description points the workflow at the new test
+
+- **WHEN** the PR for this change is opened
+- **THEN** its body contains a fenced ` ```demo-test ` block whose
+  sole content line is `test/browser/settings-slider.js`, and the PR
+  carries the `demo-test` GitHub label so the workflow runs against
+  the Railway preview deployment.

--- a/openspec/changes/restyle-settings-sliders/specs/settings-slider-style/spec.md
+++ b/openspec/changes/restyle-settings-sliders/specs/settings-slider-style/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Range inputs render as a hairline track with a circular brand thumb
+
+Every `<input type="range">` rendered by the front-end SHALL paint as a
+thin horizontal track at most `2px` tall, with the leading portion (from
+the track's start to the thumb) filled in `var(--fp-brand-primary)` and
+the trailing portion painted in a neutral dark stripe (or transparent on
+top of a dark surface). The thumb MUST be a circle of `14px ± 2px`
+diameter filled with `var(--fp-brand-primary)` and surrounded by a `2px`
+solid white border. No square corners and no decorative drop shadow MUST
+appear on the thumb. The styling MUST be driven by the global
+`packages/front/src/App.css` `input[type='range']` rule and its
+pseudo-element children so React/JSX call sites need no per-instance
+overrides.
+
+#### Scenario: WebKit track and thumb match the hairline + circular thumb contract
+
+- **WHEN** Chrome, Edge, or Safari renders a settings-page score-weight
+  slider
+- **THEN** the slider's `::-webkit-slider-runnable-track` paints as a
+  hairline `≤ 2px` tall, the leading portion equals
+  `var(--fp-brand-primary)`, and the `::-webkit-slider-thumb` is a
+  circle (`border-radius: 50%`) ≈ `14px` in diameter filled with
+  `var(--fp-brand-primary)` and bordered by a `2px solid #fff` halo,
+  with no `box-shadow` set.
+
+#### Scenario: Gecko track and thumb match the hairline + circular thumb contract
+
+- **WHEN** Firefox renders a settings-page score-weight slider
+- **THEN** the slider's `::-moz-range-track` paints as a hairline
+  `≤ 2px` tall, the leading portion equals `var(--fp-brand-primary)`,
+  and the `::-moz-range-thumb` is a circle (`border-radius: 50%`)
+  ≈ `14px` in diameter filled with `var(--fp-brand-primary)` and
+  bordered by a `2px solid #fff` halo.
+
+### Requirement: Filled-track portion follows the input value
+
+The painted brand-primary leading portion of every restyled range input SHALL grow and shrink in proportion to the input's current value relative to its `min`/`max`, using the existing `background-size`-driven technique consumed by `Settings.js#renderWeightInputs`. The CSS contract MUST therefore keep `background-image`, `background-repeat: no-repeat`, and `background-position` set on the input element itself so the inline `background-size` percentage from the React render path produces the filled portion at runtime. The JSX caller MUST NOT need any other property to make the fill respond.
+
+#### Scenario: Background-size percentage maps to filled-track width
+
+- **WHEN** `Settings.js#renderWeightInputs` renders a slider whose value
+  is half-way between its min and max
+- **THEN** the rendered element's inline `background-size` resolves to
+  approximately `50% 100%` and the visible brand-primary portion of the
+  track ends near the centre of the slider, aligned with the thumb's
+  current position.
+
+#### Scenario: Dragging the thumb updates the filled-track width
+
+- **WHEN** a user drags a score-weight slider's thumb from its initial
+  position towards the maximum end
+- **THEN** the slider's `background-size` width percentage increases in
+  step with the input's reported `value`, and the filled brand-primary
+  portion of the track visually extends to follow the thumb.
+
+### Requirement: Slider styling sources colour from the brand-primary token
+
+The restyled `input[type='range']` rule and its pseudo-element rules SHALL reference `var(--fp-brand-primary)` (and only the brand-primary token from the `--fp-brand-primary*` family) for the leading-track fill, the thumb fill, and any optional hover ring. No new `#b40089` or `rgb(180, 0, 137)` literal MAY be introduced by this change. The white halo MAY be a literal `#fff` because it is a contrast device, not part of the brand palette.
+
+#### Scenario: No brand hex literal added to the slider rule
+
+- **WHEN** a contributor greps `packages/front/src/App.css` for
+  `#b40089` or `rgb(180, 0, 137)` after this change
+- **THEN** no match falls inside the `input[type='range']` rule or its
+  pseudo-element rules; the rule references `var(--fp-brand-primary)`
+  instead.

--- a/openspec/changes/restyle-settings-sliders/tasks.md
+++ b/openspec/changes/restyle-settings-sliders/tasks.md
@@ -46,14 +46,12 @@
 
 ## 3. Wire the test into the PR-demo workflow
 
-- [ ] 3.1 Add a `demo-test` GitHub label to the PR opened from this
-  branch (a maintainer applies it on the GitHub UI; document this in
-  the PR body for re-discoverability).
-- [ ] 3.2 Author the PR body so it includes the exact fenced block
+- [x] 3.1 Author the PR body so it includes the exact fenced block
   `\`\`\`demo-test\ntest/browser/settings-slider.js\n\`\`\``, matching
   the regex `.github/workflows/pr-demo.yml` parses
-  (`/```demo-test\r?\n([\s\S]*?)```/`).
-- [ ] 3.3 After the PR is opened and the workflow runs, verify a
+  (`/```demo-test\r?\n([\s\S]*?)```/`). The author must be an `OWNER`
+  or `COLLABORATOR` for the job's `if:` guard to pass.
+- [ ] 3.2 After the PR is opened and the workflow runs, verify a
   `demo-video-pr-<n>` artifact appears on the run page and that the
   workflow comments back with a link.
 

--- a/openspec/changes/restyle-settings-sliders/tasks.md
+++ b/openspec/changes/restyle-settings-sliders/tasks.md
@@ -1,0 +1,72 @@
+## 1. Rewrite the slider CSS
+
+- [x] 1.1 In `packages/front/src/App.css`, replace the existing
+  `input[type='range']` rule so the input itself paints a transparent
+  backdrop with a `var(--fp-brand-primary)` leading-portion gradient
+  consumed at `2px` height (centred vertically via
+  `background-position: center`), keeping
+  `background-image: linear-gradient(var(--fp-brand-primary), var(--fp-brand-primary))`,
+  `background-repeat: no-repeat`, and the existing transition so
+  `Settings.js#renderWeightInputs` keeps driving the filled width via
+  inline `backgroundSize`.
+- [x] 1.2 Rewrite the `input[type='range']::-webkit-slider-thumb`
+  rule: `14px × 14px`, `border-radius: 50%`,
+  `background: var(--fp-brand-primary)`, `border: 2px solid #fff`,
+  remove `box-shadow`, keep `cursor: ew-resize`.
+- [x] 1.3 Rewrite the `input[type='range']::-webkit-slider-runnable-track`
+  rule so the track itself is `2px` tall and transparent (the input's
+  own background paints the visible hairline + fill).
+- [x] 1.4 Add new `input[type='range']::-moz-range-track` and
+  `::-moz-range-thumb` rules mirroring the WebKit ones so Firefox
+  renders the same hairline + circular thumb.
+- [x] 1.5 Audit `Settings.js#renderWeightInputs` and remove any inline
+  style entries on the `<input type="range">` that would fight the
+  new CSS contract (e.g. obsolete `height` or `background` overrides);
+  keep the `backgroundSize` driver and the `display: 'table-cell'`
+  layout.
+
+## 2. Add the demo cascade-test
+
+- [x] 2.1 Create `packages/back/test/browser/settings-slider.js`
+  modelled on `packages/back/test/browser/settings.js`: import
+  `cascade-test`, set up the shared context, navigate to `/settings`,
+  wait for `.settings-container` and the first
+  `input#weights-… [type="range"]` to render.
+- [x] 2.2 In the test, capture the initial `value` of the first
+  score-weight slider and the resolved `background-size` width via
+  `page.evaluate(() => getComputedStyle(el).backgroundSize)`.
+- [x] 2.3 Focus the slider and use `page.keyboard.press('ArrowRight')`
+  in a loop (10+ presses) followed by a mouse drag so the recorded
+  video shows visible thumb motion in both modes.
+- [x] 2.4 Assert with `chai`'s `expect` that the slider's reported
+  `value` differs from the initial value, AND that the resolved
+  `background-size` width percentage differs from its initial value,
+  satisfying both "filled-track follows value" and "demo proves the
+  control works" scenarios.
+
+## 3. Wire the test into the PR-demo workflow
+
+- [ ] 3.1 Add a `demo-test` GitHub label to the PR opened from this
+  branch (a maintainer applies it on the GitHub UI; document this in
+  the PR body for re-discoverability).
+- [ ] 3.2 Author the PR body so it includes the exact fenced block
+  `\`\`\`demo-test\ntest/browser/settings-slider.js\n\`\`\``, matching
+  the regex `.github/workflows/pr-demo.yml` parses
+  (`/```demo-test\r?\n([\s\S]*?)```/`).
+- [ ] 3.3 After the PR is opened and the workflow runs, verify a
+  `demo-video-pr-<n>` artifact appears on the run page and that the
+  workflow comments back with a link.
+
+## 4. Verify
+
+- [ ] 4.1 Run the front-end locally (`yarn workspace fomoplayer_front
+  start`), open `/settings`, drag the score-weight sliders, and
+  visually confirm the new hairline + circular thumb against the
+  mockup; check both Chromium and Firefox.
+- [ ] 4.2 Run the new cascade-test locally against a local back-end
+  (`cd packages/back && npx cascade-test
+  test/browser/settings-slider.js`) and confirm it passes.
+- [ ] 4.3 `yarn workspace fomoplayer_front build` succeeds (CRA does
+  not regress on the CSS rewrite).
+- [x] 4.4 Run `openspec validate restyle-settings-sliders --strict`
+  before requesting review.

--- a/packages/back/routes/auth.js
+++ b/packages/back/routes/auth.js
@@ -785,9 +785,9 @@ const createAuthRouter = ({
           token,
           audience: apiOrigin,
           allowedRepo: githubActionsOidcRepo,
+          logger,
         })
         if (!payload) {
-          logger.warn('Actions OIDC login rejected: invalid or unauthorized token')
           return res.status(401).json({ error: 'Invalid or unauthorized Actions token' })
         }
 

--- a/packages/back/routes/shared/github-actions-oidc.js
+++ b/packages/back/routes/shared/github-actions-oidc.js
@@ -5,33 +5,101 @@ const jwt = require('jsonwebtoken')
 
 const GITHUB_ACTIONS_ISSUER = 'https://token.actions.githubusercontent.com'
 
-const jwksClient = jwksRsa({
+const defaultJwksClient = jwksRsa({
   cache: true,
   rateLimit: true,
   jwksRequestsPerMinute: 5,
   jwksUri: `${GITHUB_ACTIONS_ISSUER}/.well-known/jwks.json`,
 })
 
-const getSigningKey = (header, callback) => {
-  jwksClient.getSigningKey(header.kid, (err, key) => {
-    if (err) return callback(err)
-    callback(null, key.getPublicKey())
-  })
+const extractUnverifiedClaims = (token) => {
+  try {
+    const decoded = jwt.decode(token, { complete: true })
+    if (!decoded || typeof decoded !== 'object') return null
+    const payload = decoded.payload && typeof decoded.payload === 'object' ? decoded.payload : {}
+    const header = decoded.header && typeof decoded.header === 'object' ? decoded.header : {}
+    return {
+      iss: payload.iss ?? null,
+      aud: payload.aud ?? null,
+      sub: payload.sub ?? null,
+      repository: payload.repository ?? null,
+      exp: payload.exp ?? null,
+      alg: header.alg ?? null,
+    }
+  } catch {
+    return null
+  }
 }
 
-const verifyActionsToken = ({ token, audience, allowedRepo }) =>
-  new Promise((resolve) => {
-    if (!token || !audience || !allowedRepo) return resolve(null)
-    jwt.verify(
-      token,
-      getSigningKey,
-      { issuer: GITHUB_ACTIONS_ISSUER, audience, algorithms: ['RS256'] },
-      (err, payload) => {
-        if (err || !payload || typeof payload !== 'object') return resolve(null)
-        if (payload.repository !== allowedRepo) return resolve(null)
-        resolve(payload)
-      },
-    )
-  })
+const createVerifyActionsToken = ({ jwksClient = defaultJwksClient } = {}) =>
+  ({ token, audience, allowedRepo, logger } = {}) =>
+    new Promise((resolve) => {
+      const safeWarn = (reason, detail) => {
+        if (typeof logger?.warn !== 'function') return
+        logger.warn({
+          reason,
+          expectedAudience: audience ?? null,
+          expectedRepo: allowedRepo ?? null,
+          issuer: GITHUB_ACTIONS_ISSUER,
+          ...detail,
+        })
+      }
 
-module.exports = { verifyActionsToken, GITHUB_ACTIONS_ISSUER }
+      if (!token || !audience || !allowedRepo) {
+        const missing = []
+        if (!token) missing.push('token')
+        if (!audience) missing.push('audience')
+        if (!allowedRepo) missing.push('allowedRepo')
+        safeWarn('verifier-input-missing', { missing })
+        return resolve(null)
+      }
+
+      let jwksFetchFailedWarned = false
+      const getSigningKey = (header, callback) => {
+        jwksClient.getSigningKey(header.kid, (err, key) => {
+          if (err) {
+            safeWarn('jwks-key-fetch-failed', {
+              kid: header?.kid ?? null,
+              errorName: err.name ?? null,
+              errorMessage: err.message ?? null,
+            })
+            jwksFetchFailedWarned = true
+            return callback(err)
+          }
+          callback(null, key.getPublicKey())
+        })
+      }
+
+      jwt.verify(
+        token,
+        getSigningKey,
+        { issuer: GITHUB_ACTIONS_ISSUER, audience, algorithms: ['RS256'] },
+        (err, payload) => {
+          if (err || !payload || typeof payload !== 'object') {
+            if (!jwksFetchFailedWarned) {
+              safeWarn('signature-or-claim-verification-failed', {
+                jwtErrorName: err?.name ?? null,
+                jwtErrorMessage: err?.message ?? null,
+                unverifiedClaims: extractUnverifiedClaims(token),
+              })
+            }
+            return resolve(null)
+          }
+          if (payload.repository !== allowedRepo) {
+            safeWarn('repository-claim-mismatch', {
+              observedRepo: payload.repository ?? null,
+            })
+            return resolve(null)
+          }
+          resolve(payload)
+        },
+      )
+    })
+
+const verifyActionsToken = createVerifyActionsToken()
+
+module.exports = {
+  verifyActionsToken,
+  createVerifyActionsToken,
+  GITHUB_ACTIONS_ISSUER,
+}

--- a/packages/back/test/browser/settings-slider.js
+++ b/packages/back/test/browser/settings-slider.js
@@ -1,0 +1,65 @@
+const { expect } = require('chai')
+const { test } = require('cascade-test')
+const { getSharedContext, dismissOnboarding, waitForWithTimeoutMessage } = require('../lib/setup')
+
+const SLIDER_SELECTOR = 'input[type="range"][id^="weights-"]'
+
+test({
+  setup: async () => {
+    const { page } = await getSharedContext()
+    await page.goto('/settings/sorting')
+    await waitForWithTimeoutMessage(
+      () => page.waitForSelector('.settings-container', { timeout: 15000 }),
+      'Render the settings container before exercising score-weight sliders.',
+    )
+    await dismissOnboarding(page)
+    await waitForWithTimeoutMessage(
+      () => page.waitForSelector(SLIDER_SELECTOR, { timeout: 15000 }),
+      'Render the score-weight slider inputs before exercising them.',
+    )
+    return { page, timeout: 30000 }
+  },
+
+  'dragging a score-weight slider updates the value and the filled-track width': async ({ page }) => {
+    await page.goto('/settings/sorting')
+    await waitForWithTimeoutMessage(
+      () => page.waitForSelector(SLIDER_SELECTOR, { timeout: 15000 }),
+      'Render the score-weight slider inputs before exercising them.',
+    )
+
+    const slider = page.locator(SLIDER_SELECTOR).first()
+    await waitForWithTimeoutMessage(
+      () => slider.waitFor({ state: 'visible', timeout: 15000 }),
+      'Reveal the first score-weight slider before interacting with it.',
+    )
+
+    const initial = await slider.evaluate((el) => ({
+      value: el.value,
+      backgroundSize: getComputedStyle(el).backgroundSize,
+    }))
+
+    await slider.focus()
+    for (let i = 0; i < 12; i++) {
+      await page.keyboard.press('ArrowRight')
+    }
+
+    const sliderBox = await slider.boundingBox()
+    if (sliderBox) {
+      const startX = sliderBox.x + sliderBox.width * 0.5
+      const y = sliderBox.y + sliderBox.height / 2
+      const endX = sliderBox.x + sliderBox.width * 0.85
+      await page.mouse.move(startX, y)
+      await page.mouse.down()
+      await page.mouse.move(endX, y, { steps: 20 })
+      await page.mouse.up()
+    }
+
+    const after = await slider.evaluate((el) => ({
+      value: el.value,
+      backgroundSize: getComputedStyle(el).backgroundSize,
+    }))
+
+    expect(after.value, 'slider value moved after keyboard/drag input').to.not.equal(initial.value)
+    expect(after.backgroundSize, 'filled-track width responded to value change').to.not.equal(initial.backgroundSize)
+  },
+})

--- a/packages/back/test/tests/users/auth/actions-oidc-login.js
+++ b/packages/back/test/tests/users/auth/actions-oidc-login.js
@@ -29,7 +29,19 @@ const mockAccount = (userId = 42) => ({
   findByUserId: async () => ({ id: userId }),
 })
 
-const createApp = ({ config = previewConfig, account = mockAccount(), verifyActionsTokenFn } = {}) => {
+const createRecordingLogger = () => {
+  const entries = []
+  const record = (level) => (...args) => entries.push({ level, args })
+  return {
+    entries,
+    warn: record('warn'),
+    info: record('info'),
+    error: record('error'),
+    debug: record('debug'),
+  }
+}
+
+const createApp = ({ config = previewConfig, account = mockAccount(), verifyActionsTokenFn, logger } = {}) => {
   const app = express()
   app.use(express.json())
   app.use((req, _, next) => {
@@ -40,7 +52,7 @@ const createApp = ({ config = previewConfig, account = mockAccount(), verifyActi
     }
     next()
   })
-  app.use('/api/auth', createAuthRouter({ account, config, verifyActionsTokenFn }))
+  app.use('/api/auth', createAuthRouter({ account, config, verifyActionsTokenFn, logger }))
   return app
 }
 
@@ -105,6 +117,28 @@ test({
     expect(capturedArgs.token).to.equal('my-token')
     expect(capturedArgs.audience).to.equal(API_ORIGIN)
     expect(capturedArgs.allowedRepo).to.equal(ALLOWED_REPO)
+    expect(capturedArgs.logger).to.exist
+    expect(typeof capturedArgs.logger.warn).to.equal('function')
+  },
+
+  'POST /login/actions — verifier rejection does not emit the old opaque warn at the route': async () => {
+    const logger = createRecordingLogger()
+    const app = createApp({
+      verifyActionsTokenFn: async () => null,
+      logger,
+    })
+    const response = await request(app)
+      .post('/api/auth/login/actions')
+      .send({ token: 'tampered-token' })
+    expect(response.status).to.equal(401)
+    const opaqueWarns = logger.entries
+      .filter((entry) => entry.level === 'warn')
+      .filter((entry) =>
+        entry.args.some(
+          (arg) => typeof arg === 'string' && arg.includes('invalid or unauthorized'),
+        ),
+      )
+    expect(opaqueWarns).to.have.length(0)
   },
 
   'POST /login/actions — uses findOrCreateByIdentifier with GitHub Actions issuer and repo as subject': async () => {

--- a/packages/back/test/tests/users/auth/actions-oidc-verifier.js
+++ b/packages/back/test/tests/users/auth/actions-oidc-verifier.js
@@ -1,0 +1,174 @@
+'use strict'
+
+const { generateKeyPairSync } = require('crypto')
+const { expect } = require('chai')
+const jwt = require('jsonwebtoken')
+const { test } = require('cascade-test')
+
+const {
+  createVerifyActionsToken,
+  GITHUB_ACTIONS_ISSUER,
+} = require('../../../../routes/shared/github-actions-oidc')
+
+const AUDIENCE = 'https://preview-pr-1.up.railway.app'
+const ALLOWED_REPO = 'owner/fomoplayer'
+
+const generateKeyPair = () =>
+  generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  })
+
+const mintToken = (privateKey, claims = {}, options = {}) =>
+  jwt.sign(
+    {
+      iss: GITHUB_ACTIONS_ISSUER,
+      aud: AUDIENCE,
+      sub: `repo:${ALLOWED_REPO}:ref:refs/heads/main`,
+      repository: ALLOWED_REPO,
+      ...claims,
+    },
+    privateKey,
+    { algorithm: 'RS256', expiresIn: '5m', keyid: 'test-kid', ...options },
+  )
+
+const fakeJwksClient = (publicKey) => ({
+  getSigningKey: (_kid, cb) => cb(null, { getPublicKey: () => publicKey }),
+})
+
+const erroringJwksClient = (error) => ({
+  getSigningKey: (_kid, cb) => cb(error),
+})
+
+const createRecordingLogger = () => {
+  const calls = []
+  return {
+    warn: (payload) => calls.push(payload),
+    calls,
+  }
+}
+
+test({
+  'verifier-input-missing — missing token logs reason and resolves null': async () => {
+    const logger = createRecordingLogger()
+    const verify = createVerifyActionsToken({ jwksClient: fakeJwksClient('unused') })
+    const result = await verify({ token: null, audience: AUDIENCE, allowedRepo: ALLOWED_REPO, logger })
+    expect(result).to.equal(null)
+    expect(logger.calls).to.have.length(1)
+    expect(logger.calls[0].reason).to.equal('verifier-input-missing')
+    expect(logger.calls[0].missing).to.deep.equal(['token'])
+    expect(logger.calls[0].expectedAudience).to.equal(AUDIENCE)
+    expect(logger.calls[0].expectedRepo).to.equal(ALLOWED_REPO)
+    expect(logger.calls[0].issuer).to.equal(GITHUB_ACTIONS_ISSUER)
+  },
+
+  'verifier-input-missing — multiple missing inputs are all listed': async () => {
+    const logger = createRecordingLogger()
+    const verify = createVerifyActionsToken({ jwksClient: fakeJwksClient('unused') })
+    const result = await verify({ token: 'x', audience: undefined, allowedRepo: undefined, logger })
+    expect(result).to.equal(null)
+    expect(logger.calls[0].missing).to.deep.equal(['audience', 'allowedRepo'])
+  },
+
+  'jwks-key-fetch-failed — JWKS error is logged with kid and error detail': async () => {
+    const logger = createRecordingLogger()
+    const { privateKey } = generateKeyPair()
+    const token = mintToken(privateKey)
+    const fetchError = new Error('boom')
+    fetchError.name = 'SigningKeyNotFoundError'
+    const verify = createVerifyActionsToken({ jwksClient: erroringJwksClient(fetchError) })
+
+    const result = await verify({ token, audience: AUDIENCE, allowedRepo: ALLOWED_REPO, logger })
+
+    expect(result).to.equal(null)
+    const jwksWarns = logger.calls.filter((c) => c.reason === 'jwks-key-fetch-failed')
+    expect(jwksWarns).to.have.length(1)
+    expect(jwksWarns[0].kid).to.equal('test-kid')
+    expect(jwksWarns[0].errorName).to.equal('SigningKeyNotFoundError')
+    expect(jwksWarns[0].errorMessage).to.equal('boom')
+    const sigWarns = logger.calls.filter((c) => c.reason === 'signature-or-claim-verification-failed')
+    expect(sigWarns).to.have.length(0)
+  },
+
+  'signature-or-claim-verification-failed — wrong signing key surfaces unverified claims': async () => {
+    const logger = createRecordingLogger()
+    const minted = generateKeyPair()
+    const otherPair = generateKeyPair()
+    const token = mintToken(minted.privateKey)
+    const verify = createVerifyActionsToken({ jwksClient: fakeJwksClient(otherPair.publicKey) })
+
+    const result = await verify({ token, audience: AUDIENCE, allowedRepo: ALLOWED_REPO, logger })
+
+    expect(result).to.equal(null)
+    expect(logger.calls).to.have.length(1)
+    expect(logger.calls[0].reason).to.equal('signature-or-claim-verification-failed')
+    expect(logger.calls[0].jwtErrorName).to.be.a('string')
+    expect(logger.calls[0].unverifiedClaims.iss).to.equal(GITHUB_ACTIONS_ISSUER)
+    expect(logger.calls[0].unverifiedClaims.aud).to.equal(AUDIENCE)
+    expect(logger.calls[0].unverifiedClaims.repository).to.equal(ALLOWED_REPO)
+    expect(logger.calls[0].unverifiedClaims.alg).to.equal('RS256')
+  },
+
+  'signature-or-claim-verification-failed — wrong audience surfaces observed aud': async () => {
+    const logger = createRecordingLogger()
+    const { privateKey, publicKey } = generateKeyPair()
+    const token = mintToken(privateKey, { aud: 'https://wrong.example.com' })
+    const verify = createVerifyActionsToken({ jwksClient: fakeJwksClient(publicKey) })
+
+    const result = await verify({ token, audience: AUDIENCE, allowedRepo: ALLOWED_REPO, logger })
+
+    expect(result).to.equal(null)
+    expect(logger.calls[0].reason).to.equal('signature-or-claim-verification-failed')
+    expect(logger.calls[0].unverifiedClaims.aud).to.equal('https://wrong.example.com')
+  },
+
+  'repository-claim-mismatch — signature verifies but repo is wrong': async () => {
+    const logger = createRecordingLogger()
+    const { privateKey, publicKey } = generateKeyPair()
+    const token = mintToken(privateKey, { repository: 'other/repo' })
+    const verify = createVerifyActionsToken({ jwksClient: fakeJwksClient(publicKey) })
+
+    const result = await verify({ token, audience: AUDIENCE, allowedRepo: ALLOWED_REPO, logger })
+
+    expect(result).to.equal(null)
+    expect(logger.calls).to.have.length(1)
+    expect(logger.calls[0].reason).to.equal('repository-claim-mismatch')
+    expect(logger.calls[0].observedRepo).to.equal('other/repo')
+    expect(logger.calls[0].expectedRepo).to.equal(ALLOWED_REPO)
+  },
+
+  'happy path — valid token resolves the payload and emits no warn': async () => {
+    const logger = createRecordingLogger()
+    const { privateKey, publicKey } = generateKeyPair()
+    const token = mintToken(privateKey)
+    const verify = createVerifyActionsToken({ jwksClient: fakeJwksClient(publicKey) })
+
+    const result = await verify({ token, audience: AUDIENCE, allowedRepo: ALLOWED_REPO, logger })
+
+    expect(result).to.be.an('object')
+    expect(result.repository).to.equal(ALLOWED_REPO)
+    expect(logger.calls).to.have.length(0)
+  },
+
+  'no-logger silent rejection — verification failure resolves null without throwing': async () => {
+    const { privateKey, publicKey } = generateKeyPair()
+    const token = mintToken(privateKey, { repository: 'other/repo' })
+    const verify = createVerifyActionsToken({ jwksClient: fakeJwksClient(publicKey) })
+    const result = await verify({ token, audience: AUDIENCE, allowedRepo: ALLOWED_REPO })
+    expect(result).to.equal(null)
+  },
+
+  'no-logger silent rejection — logger without .warn function does not throw': async () => {
+    const { privateKey, publicKey } = generateKeyPair()
+    const token = mintToken(privateKey, { repository: 'other/repo' })
+    const verify = createVerifyActionsToken({ jwksClient: fakeJwksClient(publicKey) })
+    const result = await verify({
+      token,
+      audience: AUDIENCE,
+      allowedRepo: ALLOWED_REPO,
+      logger: { warn: 'not-a-function' },
+    })
+    expect(result).to.equal(null)
+  },
+})

--- a/packages/front/src/App.css
+++ b/packages/front/src/App.css
@@ -239,13 +239,19 @@ audio {
 
 input[type='range'] {
   -webkit-appearance: none;
+  appearance: none;
   width: 10rem;
   height: 1rem;
   margin: 5px;
-  background: #222;
-  border-radius: 0.25rem;
+  padding: calc(0.5rem - 1px) 0;
+  box-sizing: border-box;
+  border: none;
+  background-color: transparent;
   background-image: linear-gradient(var(--fp-brand-primary), var(--fp-brand-primary));
   background-repeat: no-repeat;
+  background-position: center;
+  background-origin: content-box;
+  background-clip: content-box;
   transition:
     box-shadow 0.25s ease-in-out,
     width 0.25s ease-in-out;
@@ -253,20 +259,38 @@ input[type='range'] {
 
 input[type='range']::-webkit-slider-thumb {
   -webkit-appearance: none;
-  height: 1rem;
-  width: 1rem;
-  border-radius: 0.25rem;
-  background: white;
+  appearance: none;
+  height: 14px;
+  width: 14px;
+  margin-top: -6px;
+  border-radius: 50%;
+  background: var(--fp-brand-primary);
+  border: 2px solid #fff;
   cursor: ew-resize;
   transition: background 0.3s ease-in-out;
-  box-shadow: 0 0 2px 0 #555;
 }
 
 input[type='range']::-webkit-slider-runnable-track {
   -webkit-appearance: none;
-  box-shadow: none;
-  border: none;
+  height: 2px;
   background: transparent;
+  border: none;
+  box-shadow: none;
+}
+
+input[type='range']::-moz-range-track {
+  height: 2px;
+  background: transparent;
+  border: none;
+}
+
+input[type='range']::-moz-range-thumb {
+  height: 14px;
+  width: 14px;
+  border-radius: 50%;
+  background: var(--fp-brand-primary);
+  border: 2px solid #fff;
+  cursor: ew-resize;
 }
 
 .react-joyride__tooltip button:disabled {


### PR DESCRIPTION
## Summary

- Restyle the settings score-weight sliders as a 2px brand-coloured hairline track with a 14px circular brand thumb ringed in white, matching the mockup. Pure-CSS change in `packages/front/src/App.css` with Firefox parity via `::-moz-range-track` / `::-moz-range-thumb`. The existing JSX `backgroundSize` driver in `Settings.js#renderWeightInputs` keeps working unchanged because the gradient is constrained to a 2px content box via padding + `background-clip: content-box`.
- Add `packages/back/test/browser/settings-slider.js`: a cascade-test that drives the slider via keyboard + mouse drag and asserts the value and computed `background-size` respond. Doubles as the demo vehicle for `pr-demo.yml`.

`auto-label-demo-test.yml` (landed separately on master) should pick up the fenced block below and apply the `demo-test` label automatically.

## Test plan

- [ ] `/settings/sorting` shows the new hairline + circular brand thumb in Chromium and Firefox.
- [ ] Dragging a score-weight slider extends the brand fill in step with the thumb.
- [ ] `cd packages/back && npx cascade-test test/browser/settings-slider.js` passes against a local backend.
- [ ] `yarn workspace fomoplayer_front build` succeeds.
- [ ] The PR-demo workflow runs against the Railway preview and uploads `demo-video-pr-<n>` as an artifact, with a comment on this PR linking to the run.

```demo-test
test/browser/settings-slider.js
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned settings score-weight sliders: ≤2px hairline track, circular brand-colored thumb with white halo; consistent WebKit/Firefox appearance.

* **Tests**
  * Added a browser cascade test to verify slider interactions update both the numeric value and the visual filled track.
  * Added verifier and route tests to validate structured OIDC diagnostic logging and no-op behavior when logger is absent.

* **Documentation**
  * Added design, proposal, spec, and task docs for slider restyle, demo-test opt-in workflow, and OIDC diagnostics.

* **Refactor**
  * Moved Actions OIDC logging into a configurable verifier to emit structured warning reasons.

* **Chores**
  * Added change metadata entries for both changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gadgetmies/fomoplayer/pull/349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->