### PR TITLE
Fix AirPods double-click to add current track to default cart

### DIFF
--- a/packages/front/src/Player.js
+++ b/packages/front/src/Player.js
@@ -217,7 +217,7 @@ class Player extends Component {
       this.setState({ playPauseDoubleClickStarted: true })
       setTimeout(() => {
         this.setState({ playPauseDoubleClickStarted: false })
-      }, 200)
+      }, 500)
     }
   }
 

--- a/packages/front/src/Player.js
+++ b/packages/front/src/Player.js
@@ -208,9 +208,11 @@ class Player extends Component {
     if (!['keyboard', 'media'].includes(source)) return
 
     // The flag is kept on the instance rather than in state on purpose:
-    // media-key events (e.g. an AirPods double-tap) arrive within the same
-    // React 18 batch, so a setState flag would still read its stale value on
-    // the second event and the double-click would never be detected.
+    // media-key events arrive in the same React 18 batch, so a setState flag
+    // would still read its stale value on the second event and the
+    // double-click would never be detected. The window is intentionally wide
+    // (1s): on AirPods a fast double-press triggers the OS skip gesture, so the
+    // two play/pause presses must be deliberately spaced out to reach us.
     if (this._playPauseDoubleClickStarted) {
       clearTimeout(this._playPauseDoubleClickTimer)
       this._playPauseDoubleClickStarted = false
@@ -222,7 +224,7 @@ class Player extends Component {
       this._playPauseDoubleClickStarted = true
       this._playPauseDoubleClickTimer = setTimeout(() => {
         this._playPauseDoubleClickStarted = false
-      }, 500)
+      }, 1000)
     }
   }
 

--- a/packages/front/src/Player.js
+++ b/packages/front/src/Player.js
@@ -13,7 +13,6 @@ class Player extends Component {
     this.state = {
       listenedTracks: 0,
       togglingCurrentInCart: false,
-      playPauseDoubleClickStarted: false,
       helpActive: false,
       enabledStores,
       enabledStoreSearch,
@@ -206,17 +205,23 @@ class Player extends Component {
 
   async handlePlayPauseToggle(playing, source) {
     if (this.props.mode !== 'app') return
-    const isKeyboardOrMedia = ['keyboard', 'media'].includes(source)
+    if (!['keyboard', 'media'].includes(source)) return
 
-    if (playing && this.state.playPauseDoubleClickStarted) {
-      this.setState({ playPauseDoubleClickStarted: false })
-      if (isKeyboardOrMedia) {
-        await this.props.onAddToCart(this.getDefaultCart().id, this.props.currentTrack.id)
+    // The flag is kept on the instance rather than in state on purpose:
+    // media-key events (e.g. an AirPods double-tap) arrive within the same
+    // React 18 batch, so a setState flag would still read its stale value on
+    // the second event and the double-click would never be detected.
+    if (this._playPauseDoubleClickStarted) {
+      clearTimeout(this._playPauseDoubleClickTimer)
+      this._playPauseDoubleClickStarted = false
+      const defaultCart = this.getDefaultCart()
+      if (defaultCart && this.props.currentTrack) {
+        await this.props.onAddToCart(defaultCart.id, this.props.currentTrack.id)
       }
-    } else if (!playing && isKeyboardOrMedia) {
-      this.setState({ playPauseDoubleClickStarted: true })
-      setTimeout(() => {
-        this.setState({ playPauseDoubleClickStarted: false })
+    } else {
+      this._playPauseDoubleClickStarted = true
+      this._playPauseDoubleClickTimer = setTimeout(() => {
+        this._playPauseDoubleClickStarted = false
       }, 500)
     }
   }


### PR DESCRIPTION
Adding the current track to the default cart via a play/pause double-click did not work from AirPods.

## Root cause
The detector stored its flag in `this.state.playPauseDoubleClickStarted`. Under React 18 automatic batching, the two media-key events fire in the same batch, so the second handler read the stale (`false`) state and the cart-add branch never ran. Tuning the timeout could not fix this.

## Changes
- Track the double-click flag on the instance instead of React state, so the second event reads it synchronously (immune to batching).
- Make detection order-independent: works whether the track starts playing or paused, and even if the OS emits two identical commands. Clears the pending reset timer on a hit and guards the default-cart / current-track lookups.
- Widen the window to 1s. A fast double-press on AirPods is consumed by the OS skip gesture, so the two play/pause presses must be deliberately spaced out to reach the app.

## How to use
Press play/pause twice with a deliberate gap (slow enough that AirPods doesn't treat it as a skip) within 1s, and the current track is added to the default cart. Only keyboard/media events are eligible, so plain UI clicks won't add to the cart.

https://claude.ai/code/session_01PMHHMM88TFbZuvVdPVxfoR