### PR TITLE
Send admin email when a store integration test job fails

### DIFF
--- a/packages/back/job-scheduling.js
+++ b/packages/back/job-scheduling.js
@@ -7,7 +7,7 @@ const fetchBandcampWatches = require('./jobs/watches/fetch-bandcamp-watches')({
   batchSize: 20,
   refreshInterval: '6 hours',
 })
-const { sendNextEmailBatch } = require('./services/mailer')
+const { sendNextEmailBatch, scheduleEmail } = require('./services/mailer')
 const { updateNotifications } = require('./jobs/notifications')
 const { updateTrackDetails } = require('./jobs/track_details')
 const {
@@ -94,6 +94,20 @@ SET job_run_ended   = NOW(),
   job_run_result  = ${JSON.stringify(res)}
 WHERE job_run_id = ${job_run_id}`,
   )
+
+  if (!success && jobName.endsWith('IntegrationTest')) {
+    // Store integration test jobs are named '<store>IntegrationTest'; alert admins by email when one fails.
+    try {
+      await scheduleEmail(
+        process.env.ADMIN_EMAIL_SENDER,
+        process.env.ADMIN_EMAIL_RECIPIENT,
+        `URGENT! Integration test '${jobName}' failed!`,
+        `The integration test job '${jobName}' failed (job_run_id: ${job_run_id}).\n\nResult: ${JSON.stringify(res)}`,
+      )
+    } catch (e) {
+      logger.error(`Failed to queue failure notification email for ${jobName}: ${e.toString()}`)
+    }
+  }
 
   logger.info(`Job ${jobName} run complete`)
 }

--- a/packages/back/jobs/integration/bandcamp.js
+++ b/packages/back/jobs/integration/bandcamp.js
@@ -1,5 +1,4 @@
 const { getArtistTracks, getLabelTracks, getPlaylistTracks, storeName } = require('../../routes/stores/bandcamp/logic')
-const { scheduleEmail } = require('../../services/mailer')
 const logger = require('fomoplayer_shared').logger(__filename)
 const sql = require('sql-template-strings')
 const pg = require('fomoplayer_shared').db.pg
@@ -19,7 +18,7 @@ const requiredTrackProperties = [
 ]
 
 async function getArtistDetails() {
-  const [details] = pg.queryRowsAsync(sql`
+  const [details] = await pg.queryRowsAsync(sql`
     -- Bandcamp integration test job get artist store id
     SELECT store__artist_store_id AS "artistStoreId", store__artist_url AS url
     FROM
@@ -33,7 +32,7 @@ async function getArtistDetails() {
 }
 
 async function getLabelDetails() {
-  const [details] = pg.queryRowsAsync(sql`
+  const [details] = await pg.queryRowsAsync(sql`
     -- Bandcamp integration test job get artist store id
     SELECT store__label_store_id AS "labelStoreId", store__label_url AS url
     FROM
@@ -64,17 +63,18 @@ module.exports = async () => {
       for await (const { tracks, errors } of generator) {
         if (errors.length > 0) {
           logger.error(`Errors in fetching tracks for (${details.url}): ${JSON.stringify(errors)}`)
-          combinedErrors.concat(errors)
+          combinedErrors.push(...errors)
         }
 
         if (tracks.length === 0) {
           const error = `No tracks fetched for (${details.url})`
           logger.error(error)
           combinedErrors.push(error)
+          continue
         }
 
         const missingTrackProperties = requiredTrackProperties.filter(
-          (prop) => tracks[0].hasOwnProperty(prop) && tracks[0][prop] !== null,
+          (prop) => !tracks[0].hasOwnProperty(prop) || tracks[0][prop] === null,
         )
 
         if (missingTrackProperties.length !== 0) {
@@ -92,12 +92,6 @@ module.exports = async () => {
   }
 
   if (combinedErrors.length !== 0) {
-    await scheduleEmail(
-      process.env.ADMIN_EMAIL_SENDER,
-      process.env.ADMIN_EMAIL_RECIPIENT,
-      'URGENT! Bandcamp artist track fetching failed!',
-      `Errors: ${JSON.stringify(combinedErrors)}`,
-    )
     return { result: combinedErrors, success: false }
   }
 

--- a/packages/back/jobs/integration/beatport.js
+++ b/packages/back/jobs/integration/beatport.js
@@ -1,5 +1,4 @@
 const { getArtistTracks, getLabelTracks, getPlaylistTracks, storeName } = require('../../routes/stores/beatport/logic')
-const { scheduleEmail } = require('../../services/mailer')
 const logger = require('fomoplayer_shared').logger(__filename)
 const sql = require('sql-template-strings')
 const pg = require('fomoplayer_shared').db.pg
@@ -25,7 +24,7 @@ const requiredTrackProperties = [
 ]
 
 async function getArtistDetails() {
-  const [details] = pg.queryRowsAsync(sql`
+  const [details] = await pg.queryRowsAsync(sql`
     -- Beatport integration test job get artist store id
     SELECT store__artist_store_id AS "artistStoreId", store__artist_url AS url
     FROM
@@ -39,7 +38,7 @@ async function getArtistDetails() {
 }
 
 async function getLabelDetails() {
-  const [details] = pg.queryRowsAsync(sql`
+  const [details] = await pg.queryRowsAsync(sql`
     -- Beatport integration test job get artist store id
     SELECT store__label_store_id AS "labelStoreId", store__label_url AS url
     FROM
@@ -70,17 +69,18 @@ module.exports = async () => {
       for await (const { tracks, errors } of generator) {
         if (errors.length > 0) {
           logger.error(`Errors in fetching tracks for (${details.url}): ${JSON.stringify(errors)}`)
-          combinedErrors.concat(errors)
+          combinedErrors.push(...errors)
         }
 
         if (tracks.length === 0) {
           const error = `No tracks fetched for (${details.url})`
           logger.error(error)
           combinedErrors.push(error)
+          continue
         }
 
         const missingTrackProperties = requiredTrackProperties.filter(
-          (prop) => tracks[0].hasOwnProperty(prop) && tracks[0][prop] !== null,
+          (prop) => !tracks[0].hasOwnProperty(prop) || tracks[0][prop] === null,
         )
 
         if (missingTrackProperties.length !== 0) {
@@ -98,12 +98,6 @@ module.exports = async () => {
   }
 
   if (combinedErrors.length !== 0) {
-    await scheduleEmail(
-      process.env.ADMIN_EMAIL_SENDER,
-      process.env.ADMIN_EMAIL_RECIPIENT,
-      'URGENT! Beatport artist track fetching failed!',
-      `Errors: ${JSON.stringify(combinedErrors)}`,
-    )
     return { result: combinedErrors, success: false }
   }
 


### PR DESCRIPTION
The beatport/bandcamp integration test jobs had email-on-failure code that never ran: the detail queries were missing `await`, so the jobs threw before reaching the email call. Two other bugs (inverted missing-property filter, no-op `concat`) meant failures were detected incorrectly even if reached.

Centralize the failure email in runJob so any *IntegrationTest job that ends with success=false (including thrown exceptions) alerts admins, and fix the failure-detection bugs so the alert reflects real failures.

https://claude.ai/code/session_01NsWjhgQfa7XiFzCvgFGDUd