### PR TITLE
Refactor follow results display with tabbed interface

### DIFF
--- a/packages/front/src/Settings.js
+++ b/packages/front/src/Settings.js
@@ -134,6 +134,7 @@ class Settings extends Component {
       followedArtistsExportSuccess: null,
       authorizations: [],
       followedTab: 'artists',
+      followResultsTab: 'artist',
       followedArtistsFilter: '',
       followedLabelsFilter: '',
       followedPlaylistsFilter: '',
@@ -332,6 +333,86 @@ class Settings extends Component {
 
   onShowFollowedTab(tab) {
     this.setState({ followedTab: tab })
+  }
+
+  onShowFollowResultsTab(tab) {
+    this.setState({ followResultsTab: tab })
+  }
+
+  renderFollowResults() {
+    const groupedByType = R.groupBy(R.prop('type'), this.state.followDetails)
+    const tabs = [
+      ['artist', 'Artists'],
+      ['label', 'Labels'],
+      ['playlist', 'Playlists'],
+    ].filter(([type]) => (groupedByType[type] ?? []).length > 0)
+    const activeTab = tabs.some(([type]) => type === this.state.followResultsTab)
+      ? this.state.followResultsTab
+      : tabs[0]?.[0]
+    const items = groupedByType[activeTab] ?? []
+
+    return (
+      <>
+        <div
+          className="select-button select-button--container state-select-button--container noselect"
+          style={{ marginTop: 16, marginBottom: 16 }}
+        >
+          {tabs.map(([type, label]) => (
+            <React.Fragment key={type}>
+              <input
+                type="radio"
+                id={`settings-follow-results-${type}`}
+                name="settings-follow-results"
+                checked={activeTab === type}
+                onChange={() => this.onShowFollowResultsTab(type)}
+              />
+              <label
+                className="select_button-button  select_button-button__large"
+                htmlFor={`settings-follow-results-${type}`}
+              >
+                {label} ({groupedByType[type].length})
+              </label>
+            </React.Fragment>
+          ))}
+        </div>
+        {R.sortBy(
+          R.prop(0),
+          Object.entries(
+            R.groupBy(
+              R.propSatisfies(
+                (name) => name.toLocaleLowerCase() !== this.state.followQuery.toLocaleLowerCase(),
+                'name',
+              ),
+              items,
+            ),
+          ),
+        ).map(([isNotExactMatch, grouped]) => (
+          <React.Fragment key={`${activeTab}-${isNotExactMatch}`}>
+            {activeTab !== 'playlist' && (
+              <h6>{isNotExactMatch === 'true' ? 'Related:' : 'Exact matches:'}</h6>
+            )}
+            <ul className={'no-style-list follow-list'}>
+              {grouped.map(({ id, name, store: { name: storeName }, type, url, img }) => (
+                <li key={`${storeName}-${type}-${id ?? url}`}>
+                  <FollowItemButton
+                    id={id}
+                    name={name}
+                    storeName={storeName}
+                    type={type}
+                    url={url}
+                    img={img}
+                    disabled={this.getFollowItemDisabled(type, { id, url, storeName })}
+                    loading={this.state.updatingFollowWithUrl === url}
+                    onClick={(() => this.onFollowItemClick(url, name, type)).bind(this)}
+                    data-onboarding-id="follow-item"
+                  />
+                </li>
+              ))}
+            </ul>
+          </React.Fragment>
+        ))}
+      </>
+    )
   }
 
   async setScoreWeight(property, value) {
@@ -705,58 +786,7 @@ class Settings extends Component {
                   </>
                 ) : this.state.followDetails === undefined ? null : (
                   <>
-                    {this.state.followDetails.length === 0 ? (
-                      'No results found'
-                    ) : (
-                      <div>
-                        {R.sortBy(R.prop(0), Object.entries(R.groupBy(R.prop('type'), this.state.followDetails))).map(
-                          ([type, items]) => (
-                            <React.Fragment key={type}>
-                              <h5>
-                                {type[0].toLocaleUpperCase()}
-                                {type.substring(1)}s
-                              </h5>
-                              {R.sortBy(
-                                R.prop(0),
-                                Object.entries(
-                                  R.groupBy(
-                                    R.propSatisfies(
-                                      (name) => name.toLocaleLowerCase() !== this.state.followQuery.toLocaleLowerCase(),
-                                      'name',
-                                    ),
-                                    items,
-                                  ),
-                                ),
-                              ).map(([isNotExactMatch, grouped]) => (
-                                <React.Fragment key={`${type}-${isNotExactMatch}`}>
-                                  {type !== 'playlist' && (
-                                    <h6>{isNotExactMatch === 'true' ? 'Related:' : 'Exact matches:'}</h6>
-                                  )}
-                                  <ul className={'no-style-list follow-list'}>
-                                    {grouped.map(({ id, name, store: { name: storeName }, type, url, img }) => (
-                                      <li key={`${storeName}-${type}-${id ?? url}`}>
-                                        <FollowItemButton
-                                          id={id}
-                                          name={name}
-                                          storeName={storeName}
-                                          type={type}
-                                          url={url}
-                                          img={img}
-                                          disabled={this.getFollowItemDisabled(type, { id, url, storeName })}
-                                          loading={this.state.updatingFollowWithUrl === url}
-                                          onClick={(() => this.onFollowItemClick(url, name, type)).bind(this)}
-                                          data-onboarding-id="follow-item"
-                                        />
-                                      </li>
-                                    ))}
-                                  </ul>
-                                </React.Fragment>
-                              ))}
-                            </React.Fragment>
-                          ),
-                        )}
-                      </div>
-                    )}
+                    {this.state.followDetails.length === 0 ? 'No results found' : this.renderFollowResults()}
                   </>
                 )}
                 {this.props.stores.includes('spotify') && (


### PR DESCRIPTION
## Summary
Refactored the follow search results display in Settings to use a tabbed interface for filtering by type (artists, labels, playlists), improving UX for results with mixed content types.

## Changes
- Added `followResultsTab` state to track the active results tab
- Extracted follow results rendering logic into a new `renderFollowResults()` method
- Implemented tabbed navigation showing only tabs for types that have results
- Results are now grouped by type with tab counts, and users can switch between tabs
- Maintained existing exact match vs. related results grouping within each tab
- Simplified the JSX in the main render method by delegating to the new method

## Implementation Details
- Tabs are dynamically generated based on which types have results (artists, labels, playlists)
- The active tab defaults to the first available type if the current selection has no results
- Tab labels include result counts for each type
- Exact match/related grouping logic is preserved and applied per-tab
- Uses Ramda utilities for grouping and filtering operations consistent with existing code style

https://claude.ai/code/session_01189VB3WmPvnURo5opsPrYR