### PR TITLE
Repair Bandcamp subdomain mismatches by converting artists to labels

### DIFF
--- a/packages/back/routes/admin/db.js
+++ b/packages/back/routes/admin/db.js
@@ -652,9 +652,30 @@ module.exports.refetchBandcampArtistTracks = async (id) => {
 // store__artist row, and the mismatch via ON DELETE CASCADE, are removed) with
 // an explicit fallback for the case where the artist is kept.
 const fixStoreArtistMismatch = async (storeArtist) => {
+  logger.info(`Fixing Bandcamp artist/label mismatch for store artist ${storeArtist.storeArtistId}`, {
+    operation: 'fixStoreArtistMismatch',
+    storeArtistId: storeArtist.storeArtistId,
+    artistId: storeArtist.artistId,
+    currentName: storeArtist.currentName,
+    subdomain: storeArtist.subdomain,
+    url: storeArtist.url,
+  })
   const { labelId, deleted } = await convertArtistToLabel(storeArtist.artistId)
   await enqueueLabelArtistRefetch(labelId)
   await clearArtistNameMismatch(storeArtist.storeArtistId)
+  logger.info(
+    `Fixed Bandcamp artist/label mismatch for store artist ${storeArtist.storeArtistId}: ` +
+      `converted artist ${storeArtist.artistId} ("${storeArtist.currentName}") to label ${labelId} ` +
+      `(artist ${deleted ? 'deleted' : 'kept'}); queued label re-fetch to re-attribute tracks`,
+    {
+      operation: 'fixStoreArtistMismatch',
+      storeArtistId: storeArtist.storeArtistId,
+      artistId: storeArtist.artistId,
+      labelId,
+      deleted,
+      labelRefetchQueued: true,
+    },
+  )
   return { storeArtistId: storeArtist.storeArtistId, fixed: true, labelId, name: storeArtist.currentName, deleted }
 }
 
@@ -735,6 +756,9 @@ const convertArtistToLabel = async (id) => {
       WHERE a.artist_id = ${parsedId}`)
     if (!artist) throw new Error(`Artist ${parsedId} not found`)
 
+    const [labelByName] = await tx.queryRowsAsync(sql`-- convertArtistToLabel label exists?
+      SELECT label_id AS id FROM label WHERE LOWER(label_name) = LOWER(${artist.name})`)
+
     let labelId
     let storeLabelId = null
     if (artist.url && artist.storeId) {
@@ -745,25 +769,59 @@ const convertArtistToLabel = async (id) => {
         null,
       ))
     } else {
-      const [existing] = await tx.queryRowsAsync(sql`-- convertArtistToLabel find label by name
-        SELECT label_id AS id FROM label WHERE LOWER(label_name) = LOWER(${artist.name})`)
       labelId =
-        existing?.id ??
+        labelByName?.id ??
         (
           await tx.queryRowsAsync(sql`-- convertArtistToLabel create label
             INSERT INTO label (label_name) VALUES (${artist.name}) RETURNING label_id AS id`)
         )[0].id
     }
 
-    const movedTracks = await tx.queryRowsAsync(sql`-- convertArtistToLabel tracks credited to artist
-      SELECT DISTINCT track_id AS id FROM track__artist WHERE artist_id = ${parsedId}`)
+    // Capture every entity touched (before-images of what we delete/clear, and
+    // exactly what we add via RETURNING) so the whole conversion can be audited
+    // and, if necessary, reverted from this single log entry.
+    const audit = {
+      operation: 'convertArtistToLabel',
+      artistId: parsedId,
+      artistName: artist.name,
+      label: { id: labelId, created: !labelByName, storeLabelId },
+      deleted: false,
+    }
+    const logAudit = () =>
+      logger.info(
+        `convertArtistToLabel: artist ${parsedId} ("${artist.name}") -> label ${labelId}` +
+          (audit.deleted ? ' (artist deleted)' : ' (artist kept)'),
+        audit,
+      )
 
-    await tx.queryAsync(sql`-- convertArtistToLabel add label credits
+    audit.storeArtistRows = await tx.queryRowsAsync(sql`-- convertArtistToLabel store__artist before
+      SELECT store__artist_id       AS "storeArtistId"
+           , store_id               AS "storeId"
+           , store__artist_store_id AS "storeArtistStoreId"
+           , store__artist_url      AS url
+           , store__artist_source   AS source
+      FROM store__artist WHERE artist_id = ${parsedId}`)
+
+    audit.trackArtistCreditsRemoved = await tx.queryRowsAsync(sql`-- convertArtistToLabel credits before
+      SELECT track_id AS "trackId", track__artist_role AS role
+      FROM track__artist WHERE artist_id = ${parsedId}`)
+    const movedTrackIds = [...new Set(audit.trackArtistCreditsRemoved.map((c) => c.trackId))]
+
+    const [mislabeledFlag] = await tx.queryRowsAsync(sql`-- convertArtistToLabel flag before
+      SELECT bandcamp_mislabeled_artist_url    AS url
+           , bandcamp_mislabeled_artist_reason AS reason
+           , bandcamp_mislabeled_artist_status AS status
+      FROM bandcamp_mislabeled_artist WHERE artist_id = ${parsedId}`)
+    audit.mislabeledFlagRemoved = mislabeledFlag || null
+
+    const labelCreditsAdded = await tx.queryRowsAsync(sql`-- convertArtistToLabel add label credits
       INSERT INTO track__label (track_id, label_id)
       SELECT ta.track_id, ${labelId}
       FROM track__artist ta
       WHERE ta.artist_id = ${parsedId}
-      ON CONFLICT ON CONSTRAINT track__label_track_id_label_id_key DO NOTHING`)
+      ON CONFLICT ON CONSTRAINT track__label_track_id_label_id_key DO NOTHING
+      RETURNING track_id AS "trackId"`)
+    audit.labelCreditsAddedTrackIds = labelCreditsAdded.map((r) => r.trackId)
 
     await tx.queryAsync(sql`-- convertArtistToLabel drop artist credits
       DELETE FROM track__artist WHERE artist_id = ${parsedId}`)
@@ -777,10 +835,8 @@ const convertArtistToLabel = async (id) => {
       WHERE artist_id = ${parsedId}
         AND store_id = (SELECT store_id FROM store WHERE store_url = ${BANDCAMP_STORE_URL})`)
 
-    await refreshTrackDetails(
-      tx,
-      movedTracks.map((t) => t.id),
-    )
+    await refreshTrackDetails(tx, movedTrackIds)
+    audit.trackDetailsRefreshed = movedTrackIds
 
     // Carry the artist's followers over to the label. Each follower of any of
     // the artist's store watches becomes a follower of the label's Bandcamp
@@ -793,6 +849,7 @@ const convertArtistToLabel = async (id) => {
         JOIN store__artist_watch saw ON saw.store__artist_watch_id = sawu.store__artist_watch_id
         JOIN store__artist sa ON sa.store__artist_id = saw.store__artist_id
       WHERE sa.artist_id = ${parsedId}`)
+    audit.followers = { count: followerCount, migrated: false, labelWatchId: null, userIds: [] }
 
     let followsMigrated = false
     if (followerCount > 0 && storeLabelId) {
@@ -802,7 +859,7 @@ const convertArtistToLabel = async (id) => {
       const [{ labelWatchId }] = await tx.queryRowsAsync(sql`-- convertArtistToLabel label watch id
         SELECT store__label_watch_id AS "labelWatchId"
         FROM store__label_watch WHERE store__label_id = ${storeLabelId}`)
-      await tx.queryAsync(sql`-- convertArtistToLabel migrate followers
+      const migratedFollowers = await tx.queryRowsAsync(sql`-- convertArtistToLabel migrate followers
         INSERT INTO store__label_watch__user (store__label_watch_id, meta_account_user_id)
         SELECT ${labelWatchId}, sawu.meta_account_user_id
         FROM
@@ -810,37 +867,69 @@ const convertArtistToLabel = async (id) => {
           JOIN store__artist_watch saw ON saw.store__artist_watch_id = sawu.store__artist_watch_id
           JOIN store__artist sa ON sa.store__artist_id = saw.store__artist_id
         WHERE sa.artist_id = ${parsedId}
-        ON CONFLICT (store__label_watch_id, meta_account_user_id) DO NOTHING`)
+        ON CONFLICT (store__label_watch_id, meta_account_user_id) DO NOTHING
+        RETURNING meta_account_user_id AS "userId"`)
+      audit.followers = {
+        count: followerCount,
+        migrated: true,
+        labelWatchId,
+        userIds: migratedFollowers.map((r) => r.userId),
+      }
       followsMigrated = true
     }
 
     // Retire the artist once it has nothing left: all tracks were re-credited
     // above, so the only thing that can keep it alive is followers we could not
     // move (no Bandcamp label store presence to attach the watch to).
-    if (followerCount > 0 && !followsMigrated) return { labelId, deleted: false }
+    if (followerCount > 0 && !followsMigrated) {
+      logAudit()
+      return { labelId, deleted: false }
+    }
 
     // Preserve each user's intent: someone who ignored this artist (entirely,
     // or only on a given label) should keep ignoring it now that it has become
     // a label, so migrate those rows into full-label ignores before dropping
     // the artist-scoped ones.
-    await tx.queryAsync(sql`-- convertArtistToLabel migrate full-artist ignores
+    audit.artistIgnoresRemoved = (
+      await tx.queryRowsAsync(sql`-- convertArtistToLabel artist ignores before
+        SELECT meta_account_user_id AS "userId" FROM user__artist_ignore WHERE artist_id = ${parsedId}`)
+    ).map((r) => r.userId)
+    audit.artistLabelIgnoresRemoved = await tx.queryRowsAsync(sql`-- convertArtistToLabel artist-label ignores before
+      SELECT meta_account_user_id AS "userId", label_id AS "labelId"
+      FROM user__artist__label_ignore WHERE artist_id = ${parsedId}`)
+
+    const labelIgnoresFromArtist = await tx.queryRowsAsync(sql`-- convertArtistToLabel migrate full-artist ignores
       INSERT INTO user__label_ignore (label_id, meta_account_user_id)
       SELECT ${labelId}, meta_account_user_id
       FROM user__artist_ignore
       WHERE artist_id = ${parsedId}
-      ON CONFLICT (label_id, meta_account_user_id) DO NOTHING`)
-    await tx.queryAsync(sql`-- convertArtistToLabel migrate artist-on-label ignores
+      ON CONFLICT (label_id, meta_account_user_id) DO NOTHING
+      RETURNING meta_account_user_id AS "userId"`)
+    const labelIgnoresFromArtistLabel = await tx.queryRowsAsync(sql`-- convertArtistToLabel migrate artist-on-label ignores
       INSERT INTO user__label_ignore (label_id, meta_account_user_id)
       SELECT ${labelId}, meta_account_user_id
       FROM user__artist__label_ignore
       WHERE artist_id = ${parsedId}
-      ON CONFLICT (label_id, meta_account_user_id) DO NOTHING`)
+      ON CONFLICT (label_id, meta_account_user_id) DO NOTHING
+      RETURNING meta_account_user_id AS "userId"`)
+    audit.labelIgnoresAdded = {
+      fromArtistIgnore: labelIgnoresFromArtist.map((r) => r.userId),
+      fromArtistLabelIgnore: labelIgnoresFromArtistLabel.map((r) => r.userId),
+    }
 
     await tx.queryAsync(sql`DELETE FROM user__artist_ignore WHERE artist_id = ${parsedId}`)
     await tx.queryAsync(sql`DELETE FROM user__artist__label_ignore WHERE artist_id = ${parsedId}`)
+
+    audit.artistGenresRemoved = (
+      await tx.queryRowsAsync(sql`-- convertArtistToLabel artist genres before
+        SELECT genre_id AS "genreId" FROM artist__genre WHERE artist_id = ${parsedId}`)
+    ).map((r) => r.genreId)
+
     await tx.queryAsync(sql`DELETE FROM artist__genre WHERE artist_id = ${parsedId}`)
     await tx.queryAsync(sql`DELETE FROM store__artist WHERE artist_id = ${parsedId}`)
     await tx.queryAsync(sql`DELETE FROM artist WHERE artist_id = ${parsedId}`)
+    audit.deleted = true
+    logAudit()
     return { labelId, deleted: true }
   })
 }
@@ -934,11 +1023,12 @@ module.exports.reassignTrack = async ({ sourceType, sourceId, targetType, target
   if ([src, tgt, track].some((n) => Number.isNaN(n))) throw new Error('Invalid id')
   if (sourceType === targetType && src === tgt) throw new Error('Source and target are the same entity')
 
-  return BPromise.using(pg.getTransaction(), async (tx) => {
+  const targetRole = targetType === 'artist' ? role || 'author' : null
+  await BPromise.using(pg.getTransaction(), async (tx) => {
     if (targetType === 'artist') {
       await tx.queryAsync(sql`-- reassignTrack add artist
         INSERT INTO track__artist (track_id, artist_id, track__artist_role)
-        VALUES (${track}, ${tgt}, ${role || 'author'})
+        VALUES (${track}, ${tgt}, ${targetRole})
         ON CONFLICT ON CONSTRAINT track__artist_track_id_artist_id_track__artist_role_key DO NOTHING`)
     } else {
       await tx.queryAsync(sql`-- reassignTrack add label
@@ -960,6 +1050,15 @@ module.exports.reassignTrack = async ({ sourceType, sourceId, targetType, target
         DELETE FROM track__label WHERE track_id = ${track} AND label_id = ${src}`)
     }
   })
+
+  // Revert by removing the added {targetType targetId} link from track ${track}
+  // and re-adding the {sourceType sourceId} link (role ${role || 'n/a'}).
+  logger.info(`reassignTrack: track ${track} ${sourceType} ${src} -> ${targetType} ${tgt}`, {
+    operation: 'reassignTrack',
+    trackId: track,
+    added: { type: targetType, id: tgt, role: targetRole },
+    removed: { type: sourceType, id: src, role: sourceType === 'artist' ? role || null : null },
+  })
 }
 
 // After reassigning, neutralise the source: clear the bogus Bandcamp store URL
@@ -971,6 +1070,17 @@ module.exports.cleanupMislabeledSource = async (type, id) => {
   if (Number.isNaN(parsedId)) throw new Error('Invalid id')
 
   if (type === 'artist') {
+    const [{ name: artistName } = {}] = await pg.queryRowsAsync(
+      sql`SELECT artist_name AS name FROM artist WHERE artist_id = ${parsedId}`,
+    )
+    const storeArtistRows = await pg.queryRowsAsync(sql`-- cleanupMislabeledSource store__artist before
+      SELECT store__artist_id       AS "storeArtistId"
+           , store_id               AS "storeId"
+           , store__artist_store_id AS "storeArtistStoreId"
+           , store__artist_url      AS url
+           , store__artist_source   AS source
+      FROM store__artist WHERE artist_id = ${parsedId}`)
+
     await pg.queryAsync(sql`-- cleanupMislabeledSource clear artist url
       UPDATE store__artist
       SET store__artist_url = NULL, store__artist_store_id = NULL
@@ -983,15 +1093,43 @@ module.exports.cleanupMislabeledSource = async (type, id) => {
                          FROM store__artist_watch saw
                            JOIN store__artist sa ON sa.store__artist_id = saw.store__artist_id
                          WHERE sa.artist_id = ${parsedId}) AS empty`)
-    if (!empty) return { deleted: false }
+    if (!empty) {
+      logger.info(`cleanupMislabeledSource: cleared Bandcamp URL for artist ${parsedId}, kept (not empty)`, {
+        operation: 'cleanupMislabeledSource',
+        type,
+        artistId: parsedId,
+        artistName,
+        storeArtistRowsCleared: storeArtistRows,
+        deleted: false,
+      })
+      return { deleted: false }
+    }
     try {
+      const audit = {
+        operation: 'cleanupMislabeledSource',
+        type,
+        artistId: parsedId,
+        artistName,
+        storeArtistRowsCleared: storeArtistRows,
+        deleted: true,
+      }
       await BPromise.using(pg.getTransaction(), async (tx) => {
+        audit.artistIgnoresRemoved = (
+          await tx.queryRowsAsync(sql`SELECT meta_account_user_id AS "userId" FROM user__artist_ignore WHERE artist_id = ${parsedId}`)
+        ).map((r) => r.userId)
+        audit.artistLabelIgnoresRemoved = await tx.queryRowsAsync(
+          sql`SELECT meta_account_user_id AS "userId", label_id AS "labelId" FROM user__artist__label_ignore WHERE artist_id = ${parsedId}`,
+        )
+        audit.artistGenresRemoved = (
+          await tx.queryRowsAsync(sql`SELECT genre_id AS "genreId" FROM artist__genre WHERE artist_id = ${parsedId}`)
+        ).map((r) => r.genreId)
         await tx.queryAsync(sql`DELETE FROM user__artist_ignore WHERE artist_id = ${parsedId}`)
         await tx.queryAsync(sql`DELETE FROM user__artist__label_ignore WHERE artist_id = ${parsedId}`)
         await tx.queryAsync(sql`DELETE FROM artist__genre WHERE artist_id = ${parsedId}`)
         await tx.queryAsync(sql`DELETE FROM store__artist WHERE artist_id = ${parsedId}`)
         await tx.queryAsync(sql`DELETE FROM artist WHERE artist_id = ${parsedId}`)
       })
+      logger.info(`cleanupMislabeledSource: deleted artist ${parsedId} ("${artistName}")`, audit)
       return { deleted: true }
     } catch (e) {
       logger.warn(`Could not delete mislabeled artist ${parsedId}: ${e.message}`)
@@ -999,6 +1137,9 @@ module.exports.cleanupMislabeledSource = async (type, id) => {
     }
   }
 
+  const [{ name: labelName } = {}] = await pg.queryRowsAsync(
+    sql`SELECT label_name AS name FROM label WHERE label_id = ${parsedId}`,
+  )
   const [{ empty }] = await pg.queryRowsAsync(sql`-- cleanupMislabeledSource label empty?
     SELECT NOT EXISTS (SELECT 1 FROM track__label WHERE label_id = ${parsedId})
        AND NOT EXISTS (SELECT 1
@@ -1007,10 +1148,25 @@ module.exports.cleanupMislabeledSource = async (type, id) => {
                        WHERE sl.label_id = ${parsedId}) AS empty`)
   if (!empty) return { deleted: false }
   try {
+    const audit = {
+      operation: 'cleanupMislabeledSource',
+      type,
+      labelId: parsedId,
+      labelName,
+      deleted: true,
+    }
     await BPromise.using(pg.getTransaction(), async (tx) => {
+      audit.storeLabelRowsRemoved = await tx.queryRowsAsync(sql`-- cleanupMislabeledSource store__label before
+        SELECT store__label_id       AS "storeLabelId"
+             , store_id              AS "storeId"
+             , store__label_store_id AS "storeLabelStoreId"
+             , store__label_url      AS url
+             , store__label_source   AS source
+        FROM store__label WHERE label_id = ${parsedId}`)
       await tx.queryAsync(sql`DELETE FROM store__label WHERE label_id = ${parsedId}`)
       await tx.queryAsync(sql`DELETE FROM label WHERE label_id = ${parsedId}`)
     })
+    logger.info(`cleanupMislabeledSource: deleted label ${parsedId} ("${labelName}")`, audit)
     return { deleted: true }
   } catch (e) {
     logger.warn(`Could not delete mislabeled label ${parsedId}: ${e.message}`)

--- a/packages/back/routes/admin/db.js
+++ b/packages/back/routes/admin/db.js
@@ -8,7 +8,7 @@ const {
   ignoreCachedMislabeled,
   flagMislabeledById,
 } = require('../shared/db/bandcampMislabeledCache')
-const { ensureLabelExists } = require('../shared/db/store')
+const { ensureLabelExists, refreshTrackDetails } = require('../shared/db/store')
 const {
   enqueueLabelArtistRefetch,
   enqueueArtistTrackRefetch,
@@ -18,9 +18,7 @@ const {
   getStoreArtistById,
   getStoreArtistByUrl,
   getBandcampStoreArtistsForArtist,
-  repointStoreArtistToName,
 } = require('../stores/bandcamp/db')
-const { fetchBandcampPageName } = require('../stores/bandcamp/logic')
 const {
   static: { nameSubdomainSimilarity, getSubdomain, nameSubdomainSimilarityThreshold },
 } = require('../stores/bandcamp/bandcamp-api')
@@ -644,24 +642,20 @@ module.exports.refetchBandcampArtistTracks = async (id) => {
   await enqueueArtistTrackRefetch(parsedId)
 }
 
-const normalizedName = (value) => (value || '').trim().toLocaleLowerCase()
-
-// Repair one mismatched Bandcamp subdomain mapping: fetch the page's real name,
-// re-point the subdomain's store__artist to a correctly named artist (created
-// if needed), queue a re-fetch to re-attribute its tracks, and clear the flag.
+// Repair one mismatched Bandcamp subdomain mapping. These mismatches are
+// label subdomains whose releases were collapsed onto a single artist named
+// after the label, so the repair treats the subdomain as a label: convert the
+// erroneously-created artist into a label of the same name (moving its tracks,
+// followers and ignores onto the label and retiring the artist), then queue a
+// background re-fetch that re-attributes each release's tracks to their real
+// per-track artists. Clearing the flag is handled by the conversion (the
+// store__artist row, and the mismatch via ON DELETE CASCADE, are removed) with
+// an explicit fallback for the case where the artist is kept.
 const fixStoreArtistMismatch = async (storeArtist) => {
-  const realName = await fetchBandcampPageName(storeArtist.url)
-  if (!realName) throw new Error(`Could not determine the Bandcamp page name for ${storeArtist.url}`)
-
-  if (normalizedName(realName) === normalizedName(storeArtist.currentName)) {
-    await clearArtistNameMismatch(storeArtist.storeArtistId)
-    return { storeArtistId: storeArtist.storeArtistId, fixed: false, reason: 'page name matches the linked artist' }
-  }
-
-  const artistId = await repointStoreArtistToName(storeArtist.storeArtistId, realName)
-  await enqueueArtistTrackRefetch(artistId)
+  const { labelId, deleted } = await convertArtistToLabel(storeArtist.artistId)
+  await enqueueLabelArtistRefetch(labelId)
   await clearArtistNameMismatch(storeArtist.storeArtistId)
-  return { storeArtistId: storeArtist.storeArtistId, fixed: true, artistId, name: realName }
+  return { storeArtistId: storeArtist.storeArtistId, fixed: true, labelId, name: storeArtist.currentName, deleted }
 }
 
 module.exports.getArtistNameMismatches = async () => getArtistNameMismatches()
@@ -697,7 +691,15 @@ module.exports.fixArtistBandcampMismatches = async (id) => {
     const subdomain = sa.subdomain || getSubdomain(sa.url)
     if (!subdomain) continue
     if (nameSubdomainSimilarity(sa.currentName, subdomain) < nameSubdomainSimilarityThreshold) {
-      results.push(await fixStoreArtistMismatch(sa))
+      // The first conversion moves all of the artist's tracks and may retire
+      // the artist, so a later subdomain of the same artist can no longer be
+      // converted; record the failure instead of aborting the whole request.
+      try {
+        results.push(await fixStoreArtistMismatch(sa))
+      } catch (e) {
+        logger.warn(`Could not fix Bandcamp mismatch for store artist ${sa.storeArtistId}: ${e.message}`)
+        results.push({ storeArtistId: sa.storeArtistId, fixed: false, reason: e.message })
+      }
     }
   }
   return { checked: rows.length, fixed: results.filter((r) => r.fixed).length, results }
@@ -713,10 +715,11 @@ module.exports.flagMislabeledEntity = async (type, id) => {
 // Re-label a Bandcamp artist that is actually a label: find/create the label
 // (by name, linking the artist's Bandcamp store URL), move every track credited
 // to the artist onto the label, drop the artist's bogus credit (leaving any
-// other artist credits intact), migrate the artist's followers into followers
-// of the label, then retire the now-empty artist and clear its mislabeled flag.
+// other artist credits intact), refresh those tracks' cached details so search
+// reflects the new label, migrate the artist's followers and ignores onto the
+// label, then retire the now-empty artist and clear its mislabeled flag.
 // Returns the new label id and whether the artist was deleted.
-module.exports.convertArtistToLabel = async (id) => {
+const convertArtistToLabel = async (id) => {
   const parsedId = parseInt(id, 10)
   if (Number.isNaN(parsedId)) throw new Error('Invalid id')
 
@@ -752,6 +755,9 @@ module.exports.convertArtistToLabel = async (id) => {
         )[0].id
     }
 
+    const movedTracks = await tx.queryRowsAsync(sql`-- convertArtistToLabel tracks credited to artist
+      SELECT DISTINCT track_id AS id FROM track__artist WHERE artist_id = ${parsedId}`)
+
     await tx.queryAsync(sql`-- convertArtistToLabel add label credits
       INSERT INTO track__label (track_id, label_id)
       SELECT ta.track_id, ${labelId}
@@ -770,6 +776,11 @@ module.exports.convertArtistToLabel = async (id) => {
       SET store__artist_url = NULL, store__artist_store_id = NULL
       WHERE artist_id = ${parsedId}
         AND store_id = (SELECT store_id FROM store WHERE store_url = ${BANDCAMP_STORE_URL})`)
+
+    await refreshTrackDetails(
+      tx,
+      movedTracks.map((t) => t.id),
+    )
 
     // Carry the artist's followers over to the label. Each follower of any of
     // the artist's store watches becomes a follower of the label's Bandcamp
@@ -808,6 +819,23 @@ module.exports.convertArtistToLabel = async (id) => {
     // move (no Bandcamp label store presence to attach the watch to).
     if (followerCount > 0 && !followsMigrated) return { labelId, deleted: false }
 
+    // Preserve each user's intent: someone who ignored this artist (entirely,
+    // or only on a given label) should keep ignoring it now that it has become
+    // a label, so migrate those rows into full-label ignores before dropping
+    // the artist-scoped ones.
+    await tx.queryAsync(sql`-- convertArtistToLabel migrate full-artist ignores
+      INSERT INTO user__label_ignore (label_id, meta_account_user_id)
+      SELECT ${labelId}, meta_account_user_id
+      FROM user__artist_ignore
+      WHERE artist_id = ${parsedId}
+      ON CONFLICT (label_id, meta_account_user_id) DO NOTHING`)
+    await tx.queryAsync(sql`-- convertArtistToLabel migrate artist-on-label ignores
+      INSERT INTO user__label_ignore (label_id, meta_account_user_id)
+      SELECT ${labelId}, meta_account_user_id
+      FROM user__artist__label_ignore
+      WHERE artist_id = ${parsedId}
+      ON CONFLICT (label_id, meta_account_user_id) DO NOTHING`)
+
     await tx.queryAsync(sql`DELETE FROM user__artist_ignore WHERE artist_id = ${parsedId}`)
     await tx.queryAsync(sql`DELETE FROM user__artist__label_ignore WHERE artist_id = ${parsedId}`)
     await tx.queryAsync(sql`DELETE FROM artist__genre WHERE artist_id = ${parsedId}`)
@@ -816,6 +844,8 @@ module.exports.convertArtistToLabel = async (id) => {
     return { labelId, deleted: true }
   })
 }
+
+module.exports.convertArtistToLabel = convertArtistToLabel
 
 const mergeCounts = (flagged, counts) => {
   const byId = new Map(counts.map((c) => [c.id, c]))
@@ -846,6 +876,8 @@ module.exports.getMislabeledEntityTracks = async (type, id) => {
            , ta.track__artist_role AS role
            , r.release_id          AS "releaseId"
            , r.release_name        AS "releaseName"
+           , sr.store__release_url AS "releaseUrl"
+           , st.store__track_url   AS "trackUrl"
            , `
         .append(artists)
         .append(sql`
@@ -854,6 +886,9 @@ module.exports.getMislabeledEntityTracks = async (type, id) => {
         JOIN track t ON t.track_id = ta.track_id
         LEFT JOIN release__track rt ON rt.track_id = t.track_id
         LEFT JOIN release r ON r.release_id = rt.release_id
+        LEFT JOIN store s ON s.store_url = ${BANDCAMP_STORE_URL}
+        LEFT JOIN store__release sr ON sr.release_id = r.release_id AND sr.store_id = s.store_id
+        LEFT JOIN store__track st ON st.track_id = t.track_id AND st.store_id = s.store_id
       WHERE ta.artist_id = ${parsedId}
       ORDER BY t.track_id, r.release_name`),
     )
@@ -868,6 +903,8 @@ module.exports.getMislabeledEntityTracks = async (type, id) => {
          , NULL           AS role
          , r.release_id   AS "releaseId"
          , r.release_name AS "releaseName"
+         , sr.store__release_url AS "releaseUrl"
+         , st.store__track_url   AS "trackUrl"
          , `
       .append(artists)
       .append(sql`
@@ -876,6 +913,9 @@ module.exports.getMislabeledEntityTracks = async (type, id) => {
       JOIN track t ON t.track_id = tl.track_id
       LEFT JOIN release__track rt ON rt.track_id = t.track_id
       LEFT JOIN release r ON r.release_id = rt.release_id
+      LEFT JOIN store s ON s.store_url = ${BANDCAMP_STORE_URL}
+      LEFT JOIN store__release sr ON sr.release_id = r.release_id AND sr.store_id = s.store_id
+      LEFT JOIN store__track st ON st.track_id = t.track_id AND st.store_id = s.store_id
     WHERE tl.label_id = ${parsedId}
     ORDER BY t.track_id, r.release_name`),
   )

--- a/packages/back/routes/shared/db/store.js
+++ b/packages/back/routes/shared/db/store.js
@@ -4,6 +4,27 @@ const sql = require('sql-template-strings')
 const { apiURL } = require('../../../config')
 const logger = require('fomoplayer_shared').logger(__filename)
 
+// Recompute the cached track_details JSON (used by track search results) for a
+// set of tracks after their artist/label credits change, so search reflects the
+// new attribution instead of stale credits. Accepts a transaction or the pool.
+module.exports.refreshTrackDetails = async (queryable, trackIds) => {
+  const ids = [...new Set((trackIds || []).filter((id) => Number.isInteger(id)))]
+  if (ids.length === 0) return
+  await queryable.queryAsync(
+    // language=PostgreSQL
+    sql`-- refreshTrackDetails
+INSERT INTO track_details (track_id, track_details_updated, track_details)
+SELECT track_id, NOW(), ROW_TO_JSON(track_details(ARRAY_AGG(track_id)))
+FROM
+  UNNEST(${ids}::INT[]) AS t(track_id)
+GROUP BY track_id
+ON CONFLICT ON CONSTRAINT track_details_track_id_key DO UPDATE
+  SET track_details         = EXCLUDED.track_details
+    , track_details_updated = NOW()
+`,
+  )
+}
+
 module.exports.queryStoreId = (storeName) =>
   pg
     .queryRowsAsync(

--- a/packages/back/routes/stores/bandcamp/db.js
+++ b/packages/back/routes/stores/bandcamp/db.js
@@ -1,7 +1,7 @@
 const pg = require('fomoplayer_shared').db.pg
 const sql = require('sql-template-strings')
 const BPromise = require('bluebird')
-const { ensureArtistExists } = require('../../shared/db/store.js')
+const { ensureArtistExists, refreshTrackDetails } = require('../../shared/db/store.js')
 
 const STORE_URL = 'https://bandcamp.com'
 
@@ -349,20 +349,6 @@ module.exports.getStoreArtistByUrl = async (url) => {
 module.exports.getBandcampStoreArtistsForArtist = async (artistId) =>
   pg.queryRowsAsync(STORE_ARTIST_SELECT(sql`sa.artist_id = ${artistId}`))
 
-// Point a Bandcamp subdomain mapping at the correct artist (creating it by name
-// if needed) so the page's tracks resolve to it. Returns the correct artist id.
-module.exports.repointStoreArtistToName = async (storeArtistId, name) =>
-  BPromise.using(pg.getTransaction(), async (tx) => {
-    const [existing] = await tx.queryRowsAsync(
-      sql`SELECT artist_id AS id FROM artist WHERE LOWER(artist_name) = LOWER(${name})`,
-    )
-    const artistId =
-      existing?.id ??
-      (await tx.queryRowsAsync(sql`INSERT INTO artist (artist_name) VALUES (${name}) RETURNING artist_id AS id`))[0].id
-    await tx.queryAsync(sql`UPDATE store__artist SET artist_id = ${artistId} WHERE store__artist_id = ${storeArtistId}`)
-    return artistId
-  })
-
 // Replace each transformed track's artist credits with the freshly extracted
 // ones, matched to the database by Bandcamp store track id. When a labelId is
 // given (label re-fetch) the label credit is re-affirmed; for artist re-fetches
@@ -370,6 +356,7 @@ module.exports.repointStoreArtistToName = async (storeArtistId, name) =>
 module.exports.reattributeTracksArtists = async (tracks, labelId = null) => {
   let updated = 0
   await BPromise.using(pg.getTransaction(), async (tx) => {
+    const updatedTrackIds = []
     for (const track of tracks) {
       const [row] = await tx.queryRowsAsync(
         // language=PostgreSQL
@@ -409,8 +396,10 @@ VALUES (${trackId}, ${labelId})
 ON CONFLICT ON CONSTRAINT track__label_track_id_label_id_key DO NOTHING`,
         )
       }
+      updatedTrackIds.push(trackId)
       updated++
     }
+    await refreshTrackDetails(tx, updatedTrackIds)
   })
   return updated
 }

--- a/packages/back/routes/stores/bandcamp/db.js
+++ b/packages/back/routes/stores/bandcamp/db.js
@@ -1,6 +1,7 @@
 const pg = require('fomoplayer_shared').db.pg
 const sql = require('sql-template-strings')
 const BPromise = require('bluebird')
+const logger = require('fomoplayer_shared').logger(__filename)
 const { ensureArtistExists, refreshTrackDetails } = require('../../shared/db/store.js')
 
 const STORE_URL = 'https://bandcamp.com'
@@ -355,6 +356,10 @@ module.exports.getBandcampStoreArtistsForArtist = async (artistId) =>
 // the labels are left untouched. Returns the number of tracks updated.
 module.exports.reattributeTracksArtists = async (tracks, labelId = null) => {
   let updated = 0
+  // Per-track before/after image so a re-attribution can be audited and, if
+  // needed, reverted: which credits were removed, which were added, and whether
+  // the label credit was newly attached.
+  const audit = []
   await BPromise.using(pg.getTransaction(), async (tx) => {
     const updatedTrackIds = []
     for (const track of tracks) {
@@ -377,6 +382,13 @@ WHERE store__track_store_id = ${track.id}
       }
       if (artists.length === 0) continue
 
+      const removedCredits = await tx.queryRowsAsync(
+        // language=PostgreSQL
+        sql`-- reattributeTracksArtists credits before
+SELECT artist_id AS "artistId", track__artist_role AS role
+FROM track__artist WHERE track_id = ${trackId}`,
+      )
+
       await tx.queryAsync(sql`DELETE FROM track__artist WHERE track_id = ${trackId}`)
       for (const { id, role } of artists) {
         await tx.queryAsync(
@@ -387,19 +399,37 @@ VALUES (${trackId}, ${id}, ${role})
 ON CONFLICT ON CONSTRAINT track__artist_track_id_artist_id_track__artist_role_key DO NOTHING`,
         )
       }
+      let labelCreditAdded = false
       if (labelId) {
-        await tx.queryAsync(
+        const added = await tx.queryRowsAsync(
           // language=PostgreSQL
           sql`-- reattributeTracksArtists ensure label
 INSERT INTO track__label (track_id, label_id)
 VALUES (${trackId}, ${labelId})
-ON CONFLICT ON CONSTRAINT track__label_track_id_label_id_key DO NOTHING`,
+ON CONFLICT ON CONSTRAINT track__label_track_id_label_id_key DO NOTHING
+RETURNING track_id`,
         )
+        labelCreditAdded = added.length > 0
       }
+      audit.push({
+        trackId,
+        storeTrackId: track.id,
+        removedCredits,
+        addedCredits: artists.map(({ id, role }) => ({ artistId: id, role })),
+        labelCreditAdded,
+      })
       updatedTrackIds.push(trackId)
       updated++
     }
     await refreshTrackDetails(tx, updatedTrackIds)
   })
+  if (updated > 0) {
+    logger.info(`reattributeTracksArtists: re-credited ${updated} track(s)`, {
+      operation: 'reattributeTracksArtists',
+      labelId,
+      trackCount: updated,
+      tracks: audit,
+    })
+  }
   return updated
 }

--- a/packages/back/routes/stores/bandcamp/logic.js
+++ b/packages/back/routes/stores/bandcamp/logic.js
@@ -70,10 +70,6 @@ module.exports.getPreviewDetails = async (previewId) => {
   throw new Error('Preview url not found for id')
 }
 
-// The display name a Bandcamp page reports for itself (e.g. "Machinedrum"),
-// used to repair subdomains linked to the wrong artist.
-module.exports.fetchBandcampPageName = async (url) => (await getPageDetailsAsync(url)).name
-
 const getArtistDetails = (module.exports.getArtistDetails = async (url) => ({ url, ...(await getArtistAsync(url)) }))
 
 module.exports.getArtistName = async (url) => {

--- a/packages/front/src/AdminMislabeled.js
+++ b/packages/front/src/AdminMislabeled.js
@@ -15,6 +15,17 @@ const REASON_LABELS = {
 
 const formatArtists = (artists) => (artists && artists.length ? artists.map((a) => `${a.name} (${a.role})`).join(', ') : '—')
 
+// Render text as a link to its Bandcamp page when a URL is known, otherwise the
+// bare text — used wherever the view names an artist, label, release or track.
+const BandcampLink = ({ url, children }) =>
+  url ? (
+    <a href={url} target="_blank" rel="noopener noreferrer">
+      {children}
+    </a>
+  ) : (
+    <>{children}</>
+  )
+
 // Search + pick an entity. With `fixedType` the type selector is hidden and the
 // search is locked to that type (used for manual flagging); otherwise the user
 // chooses artist/label (used to pick a track's reassignment target).
@@ -404,17 +415,14 @@ function AdminMislabeled() {
             <div key={m.storeArtistId} className="mislabeled-item">
               <div className="mislabeled-info">
                 <div>
-                  <strong>{m.currentName}</strong> <span className="muted">(artist {m.artistId})</span>
+                  <strong>
+                    <BandcampLink url={m.url}>{m.currentName}</BandcampLink>
+                  </strong>{' '}
+                  <span className="muted">(artist {m.artistId})</span>
                   <span className="mislabeled-reason">subdomain “{m.subdomain}”</span>
                 </div>
                 <div className="muted mislabeled-url">
-                  {m.url ? (
-                    <a href={m.url} target="_blank" rel="noopener noreferrer">
-                      {m.url}
-                    </a>
-                  ) : (
-                    '—'
-                  )}
+                  <BandcampLink url={m.url}>{m.url || '—'}</BandcampLink>
                 </div>
                 <div className="muted">similarity {m.similarity}</div>
               </div>
@@ -435,17 +443,14 @@ function AdminMislabeled() {
         <div key={entity.id} className="mislabeled-item">
           <div className="mislabeled-info">
             <div>
-              <strong>{entity.name}</strong> <span className="muted">({entity.id})</span>
+              <strong>
+                <BandcampLink url={entity.url}>{entity.name}</BandcampLink>
+              </strong>{' '}
+              <span className="muted">({entity.id})</span>
               <span className="mislabeled-reason">{REASON_LABELS[entity.reason] || entity.reason}</span>
             </div>
             <div className="muted mislabeled-url">
-              {entity.url ? (
-                <a href={entity.url} target="_blank" rel="noopener noreferrer">
-                  {entity.url}
-                </a>
-              ) : (
-                '—'
-              )}
+              <BandcampLink url={entity.url}>{entity.url || '—'}</BandcampLink>
             </div>
             <div className="muted">
               {entity.trackCount} track{entity.trackCount === 1 ? '' : 's'}
@@ -471,16 +476,12 @@ function AdminMislabeled() {
       <div className="mislabeled-detail-header">
         <div>
           <h2>
-            {type === 'artist' ? 'Artist' : 'Label'}: {selected.name} <span className="muted">({selected.id})</span>
+            {type === 'artist' ? 'Artist' : 'Label'}:{' '}
+            <BandcampLink url={selected.url}>{selected.name}</BandcampLink>{' '}
+            <span className="muted">({selected.id})</span>
           </h2>
           <div className="muted mislabeled-url">
-            {selected.url ? (
-              <a href={selected.url} target="_blank" rel="noopener noreferrer">
-                {selected.url}
-              </a>
-            ) : (
-              selected.url
-            )}
+            <BandcampLink url={selected.url}>{selected.url}</BandcampLink>
           </div>
         </div>
         <div className="mislabeled-actions">
@@ -516,24 +517,12 @@ function AdminMislabeled() {
             {tracks.map((track) => (
               <tr key={track.id}>
                 <td>
-                  {track.trackUrl ? (
-                    <a href={track.trackUrl} target="_blank" rel="noopener noreferrer">
-                      {track.title}
-                    </a>
-                  ) : (
-                    track.title
-                  )}
+                  <BandcampLink url={track.trackUrl}>{track.title}</BandcampLink>
                   {track.version ? ` (${track.version})` : ''}
                   {track.role ? <span className="muted"> · {track.role}</span> : null}
                 </td>
                 <td>
-                  {track.releaseUrl ? (
-                    <a href={track.releaseUrl} target="_blank" rel="noopener noreferrer">
-                      {track.releaseName || track.releaseUrl}
-                    </a>
-                  ) : (
-                    track.releaseName || '—'
-                  )}
+                  <BandcampLink url={track.releaseUrl}>{track.releaseName || track.releaseUrl || '—'}</BandcampLink>
                 </td>
                 <td className="muted">{formatArtists(track.artists)}</td>
                 <td>

--- a/packages/front/src/AdminMislabeled.js
+++ b/packages/front/src/AdminMislabeled.js
@@ -283,8 +283,8 @@ function AdminMislabeled() {
       })
       window.alert(
         res.fixed
-          ? `Re-pointed the page to “${res.name}” and queued re-attribution of its tracks.`
-          : `No change: ${res.reason || 'the page name already matches the linked artist'}.`,
+          ? `Converted “${res.name}” into a label and queued a re-fetch to re-attribute its tracks to their real artists.`
+          : `No change: ${res.reason || 'nothing to fix'}.`,
       )
       await fetchMismatches()
     } catch (e) {
@@ -323,8 +323,8 @@ function AdminMislabeled() {
       })
       window.alert(
         res.fixed
-          ? `Re-pointed ${url} to “${res.name}” and queued re-attribution of its tracks.`
-          : `No change: ${res.reason || 'the page name already matches the linked artist'}.`,
+          ? `Converted ${url} (“${res.name}”) into a label and queued a re-fetch to re-attribute its tracks to their real artists.`
+          : `No change: ${res.reason || 'nothing to fix'}.`,
       )
       setFixUrl('')
       await fetchMismatches()
@@ -407,7 +407,15 @@ function AdminMislabeled() {
                   <strong>{m.currentName}</strong> <span className="muted">(artist {m.artistId})</span>
                   <span className="mislabeled-reason">subdomain “{m.subdomain}”</span>
                 </div>
-                <div className="muted mislabeled-url">{m.url}</div>
+                <div className="muted mislabeled-url">
+                  {m.url ? (
+                    <a href={m.url} target="_blank" rel="noopener noreferrer">
+                      {m.url}
+                    </a>
+                  ) : (
+                    '—'
+                  )}
+                </div>
                 <div className="muted">similarity {m.similarity}</div>
               </div>
               <div className="mislabeled-actions">
@@ -430,7 +438,15 @@ function AdminMislabeled() {
               <strong>{entity.name}</strong> <span className="muted">({entity.id})</span>
               <span className="mislabeled-reason">{REASON_LABELS[entity.reason] || entity.reason}</span>
             </div>
-            <div className="muted mislabeled-url">{entity.url}</div>
+            <div className="muted mislabeled-url">
+              {entity.url ? (
+                <a href={entity.url} target="_blank" rel="noopener noreferrer">
+                  {entity.url}
+                </a>
+              ) : (
+                '—'
+              )}
+            </div>
             <div className="muted">
               {entity.trackCount} track{entity.trackCount === 1 ? '' : 's'}
               {type === 'artist' ? ` · ${entity.releaseCount} release${entity.releaseCount === 1 ? '' : 's'}` : ''}
@@ -457,7 +473,15 @@ function AdminMislabeled() {
           <h2>
             {type === 'artist' ? 'Artist' : 'Label'}: {selected.name} <span className="muted">({selected.id})</span>
           </h2>
-          <div className="muted mislabeled-url">{selected.url}</div>
+          <div className="muted mislabeled-url">
+            {selected.url ? (
+              <a href={selected.url} target="_blank" rel="noopener noreferrer">
+                {selected.url}
+              </a>
+            ) : (
+              selected.url
+            )}
+          </div>
         </div>
         <div className="mislabeled-actions">
           {type === 'artist' && (
@@ -492,11 +516,25 @@ function AdminMislabeled() {
             {tracks.map((track) => (
               <tr key={track.id}>
                 <td>
-                  {track.title}
+                  {track.trackUrl ? (
+                    <a href={track.trackUrl} target="_blank" rel="noopener noreferrer">
+                      {track.title}
+                    </a>
+                  ) : (
+                    track.title
+                  )}
                   {track.version ? ` (${track.version})` : ''}
                   {track.role ? <span className="muted"> · {track.role}</span> : null}
                 </td>
-                <td>{track.releaseName || '—'}</td>
+                <td>
+                  {track.releaseUrl ? (
+                    <a href={track.releaseUrl} target="_blank" rel="noopener noreferrer">
+                      {track.releaseName || track.releaseUrl}
+                    </a>
+                  ) : (
+                    track.releaseName || '—'
+                  )}
+                </td>
                 <td className="muted">{formatArtists(track.artists)}</td>
                 <td>
                   <EntityPicker processing={processing} onPick={(target) => reassign(track, target)} />


### PR DESCRIPTION
## Summary

Changes the repair strategy for Bandcamp subdomain mismatches from re-pointing the subdomain to a correctly-named artist to converting the erroneously-created artist into a label. This handles the root cause: label subdomains whose releases were collapsed onto a single artist, which should instead be treated as labels with per-track artist attribution.

## Key Changes

- **Repair logic overhaul**: `fixStoreArtistMismatch()` now calls `convertArtistToLabel()` instead of fetching the page name and re-pointing the subdomain. This converts the mismatched artist into a label and queues a label re-fetch to re-attribute tracks to their real per-track artists.

- **Artist-to-label conversion enhancements**:
  - Now refreshes cached track details after moving tracks to the label, so search results reflect the new attribution
  - Migrates user ignores (both full-artist and artist-on-label scoped) to the new label before retiring the artist
  - Made `convertArtistToLabel()` a module export for use by the mismatch repair flow

- **Error handling**: Wrapped mismatch fixes in try-catch to handle cases where multiple subdomains of the same artist exist; the first conversion may retire the artist, so later subdomains fail gracefully with logged warnings instead of aborting the entire request.

- **Track details API**: Added `refreshTrackDetails()` utility to recompute cached track search data after artist/label credit changes, accepting either a transaction or connection pool.

- **UI improvements**:
  - Updated alert messages to reflect the new conversion-based repair strategy
  - Made URLs in the mislabeled entities list clickable links (with fallback for missing URLs)
  - Added Bandcamp store URLs to track listings (both track and release links) for better context

- **Query improvements**: Enhanced `getMislabeledEntityTracks()` to include Bandcamp store URLs for tracks and releases, enabling the UI to link directly to Bandcamp pages.

- **Removed code**: Deleted `repointStoreArtistToName()` and `fetchBandcampPageName()` which are no longer needed by the new repair strategy.

https://claude.ai/code/session_01MVCiX2M9Fq5QGAVMCVV56S