### PR TITLE
Add job run history viewer to admin jobs page

### DIFF
--- a/packages/back/routes/admin/api.js
+++ b/packages/back/routes/admin/api.js
@@ -4,6 +4,7 @@ const { runJob } = require('../../job-scheduling')
 const {
   mergeTracks,
   getJobs,
+  getJobRuns,
   getQueryResults,
   storeConfig,
   getConfigs,
@@ -52,6 +53,10 @@ async function startJobRun(name, res) {
   await runJob(name)
   res.send('Job started')
 }
+
+router.get('/jobs/:name/runs', async ({ params: { name } }, res) => {
+  res.send(await getJobRuns(name))
+})
 
 router.get('/jobs/:name/run', ({ user: { id: userId }, params: { name } }, res) => {
   return startJobRun(name, res)

--- a/packages/back/routes/admin/db.js
+++ b/packages/back/routes/admin/db.js
@@ -69,6 +69,23 @@ ORDER BY j.job_name`,
   }))
 }
 
+module.exports.getJobRuns = async (name, limit = 20) =>
+  await pg.queryRowsAsync(
+    // language=PostgreSQL
+    sql`-- getJobRuns
+SELECT job_run_id      AS id
+     , job_run_started AS started
+     , job_run_ended   AS ended
+     , job_run_success AS success
+     , job_run_result  AS result
+FROM
+  job
+  NATURAL JOIN job_run
+WHERE job_name = ${name}
+ORDER BY job_run_started DESC
+LIMIT ${limit}`,
+  )
+
 module.exports.getQueryResults = async () =>
   await pg.queryRowsAsync(
     // language=PostgreSQL

--- a/packages/front/src/AdminJobs.css
+++ b/packages/front/src/AdminJobs.css
@@ -85,7 +85,7 @@
   border-radius: 4px;
   font-size: 0.85em;
   white-space: pre-wrap;
-  word-break: break-word;
+  overflow-wrap: anywhere;
   overflow-x: auto;
 }
 

--- a/packages/front/src/AdminJobs.css
+++ b/packages/front/src/AdminJobs.css
@@ -49,3 +49,47 @@
 .admin-jobs-status-idle {
   opacity: 0.6;
 }
+
+.admin-jobs-actions {
+  display: flex;
+  gap: 8px;
+  white-space: nowrap;
+}
+
+.admin-jobs-result-row td {
+  padding: 0;
+}
+
+.admin-jobs-runs {
+  list-style: none;
+  margin: 0;
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 420px;
+  overflow: auto;
+}
+
+.admin-jobs-run-meta {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  margin-bottom: 4px;
+}
+
+.admin-jobs-run-result {
+  margin: 0;
+  padding: 8px 10px;
+  background: rgba(127, 127, 127, 0.12);
+  border-radius: 4px;
+  font-size: 0.85em;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+}
+
+.admin-jobs-runs-message {
+  padding: 10px;
+  opacity: 0.7;
+}

--- a/packages/front/src/AdminJobs.js
+++ b/packages/front/src/AdminJobs.js
@@ -16,11 +16,38 @@ const runStatus = (job) => {
     : { label: 'Failed', className: 'admin-jobs-status-failed' }
 }
 
+function JobRuns({ state }) {
+  if (!state || state.loading) return <div className="admin-jobs-runs-message">Loading…</div>
+  if (state.error) return <div className="admin-jobs-runs-message">Failed to load runs.</div>
+  if (!state.runs || state.runs.length === 0) return <div className="admin-jobs-runs-message">No runs recorded.</div>
+
+  return (
+    <ul className="admin-jobs-runs">
+      {state.runs.map((run) => (
+        <li key={run.id} className="admin-jobs-run">
+          <div className="admin-jobs-run-meta">
+            <span className={run.success ? 'admin-jobs-status-success' : 'admin-jobs-status-failed'}>
+              {run.success ? 'Success' : run.ended ? 'Failed' : 'Running'}
+            </span>
+            <span className="muted">{formatDateTime(run.started)}</span>
+            {run.ended && <span className="muted">→ {formatDateTime(run.ended)}</span>}
+          </div>
+          <pre className="admin-jobs-run-result">
+            {run.result === null ? 'No result recorded.' : JSON.stringify(run.result, null, 2)}
+          </pre>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
 function AdminJobs() {
   const history = useHistory()
   const [jobs, setJobs] = useState([])
   const [loading, setLoading] = useState(true)
   const [launching, setLaunching] = useState(null)
+  const [expanded, setExpanded] = useState(null)
+  const [runsByJob, setRunsByJob] = useState({})
 
   const fetchJobs = useCallback(async () => {
     try {
@@ -32,6 +59,29 @@ function AdminJobs() {
       setLoading(false)
     }
   }, [])
+
+  const fetchRuns = useCallback(async (name) => {
+    setRunsByJob((prev) => ({ ...prev, [name]: { ...prev[name], loading: true, error: false } }))
+    try {
+      const runs = await requestJSONwithCredentials({ url: `${apiURL}/admin/jobs/${name}/runs` })
+      setRunsByJob((prev) => ({ ...prev, [name]: { loading: false, error: false, runs } }))
+    } catch (e) {
+      console.error(e)
+      setRunsByJob((prev) => ({ ...prev, [name]: { loading: false, error: true, runs: [] } }))
+    }
+  }, [])
+
+  const toggleResult = useCallback(
+    (name) => {
+      if (expanded === name) {
+        setExpanded(null)
+        return
+      }
+      setExpanded(name)
+      fetchRuns(name)
+    },
+    [expanded, fetchRuns],
+  )
 
   useEffect(() => {
     fetchJobs()
@@ -87,26 +137,44 @@ function AdminJobs() {
             {jobs.map((job) => {
               const status = runStatus(job)
               const busy = job.running || launching === job.name
+              const isExpanded = expanded === job.name
               return (
-                <tr key={job.name}>
-                  <td>{job.name}</td>
-                  <td className="muted">{job.schedule || '—'}</td>
-                  <td>{job.enabled ? 'Yes' : 'No'}</td>
-                  <td className="muted">{formatDateTime(job.lastRun && job.lastRun.started)}</td>
-                  <td>
-                    <span className={status.className}>{status.label}</span>
-                  </td>
-                  <td>
-                    <button
-                      type="button"
-                      className="button button-push_button button-push_button-primary button-push_button-small"
-                      disabled={busy}
-                      onClick={() => launch(job.name)}
-                    >
-                      {busy ? 'Running…' : 'Run'}
-                    </button>
-                  </td>
-                </tr>
+                <React.Fragment key={job.name}>
+                  <tr>
+                    <td>{job.name}</td>
+                    <td className="muted">{job.schedule || '—'}</td>
+                    <td>{job.enabled ? 'Yes' : 'No'}</td>
+                    <td className="muted">{formatDateTime(job.lastRun && job.lastRun.started)}</td>
+                    <td>
+                      <span className={status.className}>{status.label}</span>
+                    </td>
+                    <td className="admin-jobs-actions">
+                      <button
+                        type="button"
+                        className="button button-push_button button-push_button-small"
+                        disabled={!job.lastRun}
+                        onClick={() => toggleResult(job.name)}
+                      >
+                        {isExpanded ? 'Hide result' : 'View result'}
+                      </button>
+                      <button
+                        type="button"
+                        className="button button-push_button button-push_button-primary button-push_button-small"
+                        disabled={busy}
+                        onClick={() => launch(job.name)}
+                      >
+                        {busy ? 'Running…' : 'Run'}
+                      </button>
+                    </td>
+                  </tr>
+                  {isExpanded && (
+                    <tr className="admin-jobs-result-row">
+                      <td colSpan={6}>
+                        <JobRuns state={runsByJob[job.name]} />
+                      </td>
+                    </tr>
+                  )}
+                </React.Fragment>
               )
             })}
           </tbody>


### PR DESCRIPTION
Adds the ability to view historical runs for each job in the admin jobs interface, allowing administrators to inspect past execution results and timing.

## Changes

**Backend (`packages/back/routes/admin/`):**
- Added `getJobRuns(name, limit = 20)` database query to fetch the 20 most recent runs for a given job, including start/end times, success status, and result data
- Added GET `/admin/jobs/:name/runs` API endpoint to expose job run history

**Frontend (`packages/front/src/AdminJobs.js`):**
- Created new `JobRuns` component to display a list of job runs with status badges, timestamps, and formatted result output
- Added state management for expanded job details (`expanded`) and cached run data (`runsByJob`)
- Added `fetchRuns()` callback to load run history from the API with loading/error states
- Added `toggleResult()` callback to expand/collapse the run history for a job
- Modified job table rows to include a "View result" / "Hide result" button alongside the existing "Run" button
- Expanded rows now display the full run history in a collapsible section below the job row

**Styling (`packages/front/src/AdminJobs.css`):**
- Added `.admin-jobs-actions` for flexbox layout of multiple action buttons
- Added `.admin-jobs-runs` for scrollable list container (max-height: 420px)
- Added `.admin-jobs-run-meta` for status/timestamp display
- Added `.admin-jobs-run-result` for formatted JSON output with syntax highlighting background
- Added `.admin-jobs-runs-message` for loading/error/empty state messaging

The implementation follows existing patterns in the codebase for async data fetching and state management.

https://claude.ai/code/session_0136MCkfKf5pBxsNqCMdgSAv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added job run history viewer in the admin interface, displaying past runs per job with status, timestamps, and detailed results
  * Users can now expand and collapse individual job run details on demand

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gadgetmies/fomoplayer/pull/366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->