### PR TITLE
feat(front): make play/pause double-press add-to-cart configurable

### DIFF
--- a/packages/front/src/CartSelect.css
+++ b/packages/front/src/CartSelect.css
@@ -12,4 +12,5 @@
   overflow: hidden;
   box-sizing: border-box;
   gap: 4px;
+  max-width: 20rem;
 }

--- a/packages/front/src/CartSelectorDropDownButton.css
+++ b/packages/front/src/CartSelectorDropDownButton.css
@@ -27,4 +27,5 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  text-align: left;
 }

--- a/packages/front/src/CartSelectorDropDownButton.css
+++ b/packages/front/src/CartSelectorDropDownButton.css
@@ -2,8 +2,17 @@
   white-space: nowrap;
 }
 
+.cart-selector-toggle .button-push_button_label {
+  display: inline-block;
+  max-width: 12rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
 @media (max-width: 590px) {
   .cart-selector-toggle .button-push_button_label {
-    display: inline;
+    max-width: 8rem;
   }
 }

--- a/packages/front/src/CartSelectorDropDownButton.css
+++ b/packages/front/src/CartSelectorDropDownButton.css
@@ -1,0 +1,9 @@
+.cart-selector-toggle {
+  white-space: nowrap;
+}
+
+@media (max-width: 590px) {
+  .cart-selector-toggle .button-push_button_label {
+    display: inline;
+  }
+}

--- a/packages/front/src/CartSelectorDropDownButton.css
+++ b/packages/front/src/CartSelectorDropDownButton.css
@@ -16,3 +16,15 @@
     max-width: 8rem;
   }
 }
+
+.cart-button > svg {
+  flex-shrink: 0;
+}
+
+.cart-button .cart-button-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/packages/front/src/CartSelectorDropDownButton.js
+++ b/packages/front/src/CartSelectorDropDownButton.js
@@ -1,0 +1,115 @@
+import DropDownButton from './DropDownButton'
+import SearchBar from './SearchBar'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { NavLink } from 'react-router-dom'
+import React, { useState } from 'react'
+
+const matchesFilter = (name, filter) => !filter || name.toLocaleLowerCase().includes(filter.toLowerCase())
+
+export const CartSelectorDropDownButton = ({
+  carts,
+  selectedCartId,
+  onSelectCart,
+  onCreateCartClick,
+  disabled,
+  buttonClassName,
+  popupClassName,
+}) => {
+  const [cartFilter, setCartFilter] = useState('')
+  const [newCartName, setNewCartName] = useState('')
+
+  const selectedCart = selectedCartId ? carts.find(({ id }) => String(id) === String(selectedCartId)) : undefined
+  const label = selectedCart ? selectedCart.name : 'Default cart'
+
+  return (
+    <DropDownButton
+      icon={'cart-shopping'}
+      label={label}
+      buttonClassName={buttonClassName || ''}
+      popupClassName={`cart-popup popup_content-small ${popupClassName || ''}`}
+      buttonStyle={{ opacity: 1 }}
+      popupStyle={{ overflow: 'hidden' }}
+      disabled={disabled}
+    >
+      <div>
+        <SearchBar
+          placeholder={'Search'}
+          styles={'large dark'}
+          value={cartFilter}
+          onChange={(e) => setCartFilter(e.target.value)}
+          onClearSearch={() => setCartFilter('')}
+        />
+      </div>
+      <div
+        className={'carts-list'}
+        style={{ flex: 1 }}
+        onClick={(e) => e.stopPropagation()}
+        onDoubleClick={(e) => e.stopPropagation()}
+      >
+        {matchesFilter('Default cart', cartFilter) && (
+          <button
+            className="button button-push_button button-push_button-small button-push_button-primary cart-button"
+            onClick={(e) => {
+              e.stopPropagation()
+              onSelectCart('')
+            }}
+            key="cart-default"
+          >
+            <FontAwesomeIcon icon={selectedCartId ? 'circle' : 'circle-check'} style={{ marginRight: 6 }} /> Default cart
+          </button>
+        )}
+        {carts
+          .filter(({ is_default }) => !is_default)
+          .filter(({ name }) => matchesFilter(name, cartFilter))
+          .map(({ id: cartId, name }) => {
+            const isSelected = String(cartId) === String(selectedCartId)
+            return (
+              <button
+                className="button button-push_button button-push_button-small button-push_button-primary cart-button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onSelectCart(String(cartId))
+                }}
+                key={`cart-${cartId}`}
+              >
+                <FontAwesomeIcon icon={isSelected ? 'circle-check' : 'circle'} style={{ marginRight: 6 }} /> {name}
+              </button>
+            )
+          })}
+      </div>
+      <div style={{ paddingBottom: 24 }}>
+        <hr className={'popup-divider'} />
+        <div className={'input-layout'}>
+          <input
+            placeholder={'New cart'}
+            style={{ flex: 1 }}
+            className={'cart-popup-input text-input text-input-large text-input-dark'}
+            value={newCartName}
+            onChange={(e) => setNewCartName(e.target.value)}
+            onClick={(e) => e.stopPropagation()}
+          />
+          <button
+            className="button button-push_button button-push_button-small button-push_button-primary"
+            onClick={async (e) => {
+              e.stopPropagation()
+              setNewCartName('')
+              const created = await onCreateCartClick(newCartName)
+              if (created && created.id != null) {
+                onSelectCart(String(created.id))
+              }
+            }}
+            disabled={newCartName === ''}
+          >
+            <FontAwesomeIcon icon="plus" />
+          </button>
+        </div>
+        <hr className={'popup-divider'} />
+        <div style={{ textAlign: 'center', width: '100%' }}>
+          <NavLink to={'/settings/carts'} style={{ textAlign: 'center' }}>
+            Manage carts in settings
+          </NavLink>
+        </div>
+      </div>
+    </DropDownButton>
+  )
+}

--- a/packages/front/src/CartSelectorDropDownButton.js
+++ b/packages/front/src/CartSelectorDropDownButton.js
@@ -1,3 +1,4 @@
+import './CartSelectorDropDownButton.css'
 import DropDownButton from './DropDownButton'
 import SearchBar from './SearchBar'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -17,19 +18,28 @@ export const CartSelectorDropDownButton = ({
 }) => {
   const [cartFilter, setCartFilter] = useState('')
   const [newCartName, setNewCartName] = useState('')
+  const [open, setOpen] = useState(false)
 
   const selectedCart = selectedCartId ? carts.find(({ id }) => String(id) === String(selectedCartId)) : undefined
   const label = selectedCart ? selectedCart.name : 'Default cart'
 
+  const selectCart = (cartId) => {
+    onSelectCart(cartId)
+    setOpen(false)
+  }
+
   return (
     <DropDownButton
-      icon={'cart-shopping'}
       label={label}
-      buttonClassName={buttonClassName || ''}
+      buttonClassName={`cart-selector-toggle ${buttonClassName || ''}`}
       popupClassName={`cart-popup popup_content-small ${popupClassName || ''}`}
       buttonStyle={{ opacity: 1 }}
       popupStyle={{ overflow: 'hidden' }}
       disabled={disabled}
+      open={open}
+      openOnHover={false}
+      onOpenChanged={setOpen}
+      onClick={() => setOpen((wasOpen) => !wasOpen)}
     >
       <div>
         <SearchBar
@@ -51,11 +61,12 @@ export const CartSelectorDropDownButton = ({
             className="button button-push_button button-push_button-small button-push_button-primary cart-button"
             onClick={(e) => {
               e.stopPropagation()
-              onSelectCart('')
+              selectCart('')
             }}
             key="cart-default"
           >
-            <FontAwesomeIcon icon={selectedCartId ? 'circle' : 'circle-check'} style={{ marginRight: 6 }} /> Default cart
+            <FontAwesomeIcon icon={selectedCartId ? ['far', 'circle'] : 'circle-check'} style={{ marginRight: 6 }} />{' '}
+            Default cart
           </button>
         )}
         {carts
@@ -68,11 +79,12 @@ export const CartSelectorDropDownButton = ({
                 className="button button-push_button button-push_button-small button-push_button-primary cart-button"
                 onClick={(e) => {
                   e.stopPropagation()
-                  onSelectCart(String(cartId))
+                  selectCart(String(cartId))
                 }}
                 key={`cart-${cartId}`}
               >
-                <FontAwesomeIcon icon={isSelected ? 'circle-check' : 'circle'} style={{ marginRight: 6 }} /> {name}
+                <FontAwesomeIcon icon={isSelected ? 'circle-check' : ['far', 'circle']} style={{ marginRight: 6 }} />{' '}
+                {name}
               </button>
             )
           })}
@@ -95,7 +107,7 @@ export const CartSelectorDropDownButton = ({
               setNewCartName('')
               const created = await onCreateCartClick(newCartName)
               if (created && created.id != null) {
-                onSelectCart(String(created.id))
+                selectCart(String(created.id))
               }
             }}
             disabled={newCartName === ''}
@@ -105,7 +117,7 @@ export const CartSelectorDropDownButton = ({
         </div>
         <hr className={'popup-divider'} />
         <div style={{ textAlign: 'center', width: '100%' }}>
-          <NavLink to={'/settings/carts'} style={{ textAlign: 'center' }}>
+          <NavLink to={'/settings/carts'} onClick={() => setOpen(false)} style={{ textAlign: 'center' }}>
             Manage carts in settings
           </NavLink>
         </div>

--- a/packages/front/src/CartSelectorDropDownButton.js
+++ b/packages/front/src/CartSelectorDropDownButton.js
@@ -65,8 +65,8 @@ export const CartSelectorDropDownButton = ({
             }}
             key="cart-default"
           >
-            <FontAwesomeIcon icon={selectedCartId ? ['far', 'circle'] : 'circle-check'} style={{ marginRight: 6 }} />{' '}
-            Default cart
+            <FontAwesomeIcon icon={selectedCartId ? ['far', 'circle'] : 'circle-check'} style={{ marginRight: 6 }} />
+            <span className="cart-button-name">Default cart</span>
           </button>
         )}
         {carts
@@ -83,8 +83,8 @@ export const CartSelectorDropDownButton = ({
                 }}
                 key={`cart-${cartId}`}
               >
-                <FontAwesomeIcon icon={isSelected ? 'circle-check' : ['far', 'circle']} style={{ marginRight: 6 }} />{' '}
-                {name}
+                <FontAwesomeIcon icon={isSelected ? 'circle-check' : ['far', 'circle']} style={{ marginRight: 6 }} />
+                <span className="cart-button-name">{name}</span>
               </button>
             )
           })}

--- a/packages/front/src/DropDown.js
+++ b/packages/front/src/DropDown.js
@@ -9,6 +9,7 @@ const DropDown = (props) => {
       style={props.style}
       open={props.open}
       openOnHover={props.openOnHover}
+      onOpenChanged={props.onOpenChanged}
       anchor={props.anchor}
       popupClassName={props.popupClassName}
       popupStyle={props.popupStyle}

--- a/packages/front/src/DropDownButton.js
+++ b/packages/front/src/DropDownButton.js
@@ -24,6 +24,7 @@ const DropDownButton = (props) => {
     popupStyle,
     open,
     openOnHover,
+    onOpenChanged,
     ...rest
   } = props
 
@@ -43,6 +44,7 @@ const DropDownButton = (props) => {
       <DropDown
         open={open}
         openOnHover={openOnHover}
+        onOpenChanged={onOpenChanged}
         disabled={disabled}
         anchor={
           <button

--- a/packages/front/src/Player.js
+++ b/packages/front/src/Player.js
@@ -221,9 +221,12 @@ class Player extends Component {
     if (this._playPauseDoubleClickStarted) {
       clearTimeout(this._playPauseDoubleClickTimer)
       this._playPauseDoubleClickStarted = false
-      const defaultCart = this.getDefaultCart()
-      if (defaultCart && this.props.currentTrack) {
-        await this.props.onAddToCart(defaultCart.id, this.props.currentTrack.id)
+      const configuredCartId = localStorage.getItem('playPauseDoubleClickCartId')
+      const targetCart =
+        (configuredCartId && this.props.carts.find((cart) => String(cart.id) === configuredCartId)) ||
+        this.getDefaultCart()
+      if (targetCart && this.props.currentTrack) {
+        await this.props.onAddToCart(targetCart.id, this.props.currentTrack.id)
       }
     } else {
       this._playPauseDoubleClickStarted = true

--- a/packages/front/src/Player.js
+++ b/packages/front/src/Player.js
@@ -207,12 +207,17 @@ class Player extends Component {
     if (this.props.mode !== 'app') return
     if (!['keyboard', 'media'].includes(source)) return
 
+    // Double-pressing play/pause to add the current track to the default cart
+    // is opt-out and configurable per device (see the Player settings tab).
+    if ((localStorage.getItem('playPauseDoubleClickAddToCart') || 'true') !== 'true') return
+
     // The flag is kept on the instance rather than in state on purpose:
     // media-key events arrive in the same React 18 batch, so a setState flag
     // would still read its stale value on the second event and the
-    // double-click would never be detected. The window is intentionally wide
-    // (1s): on AirPods a fast double-press triggers the OS skip gesture, so the
-    // two play/pause presses must be deliberately spaced out to reach us.
+    // double-click would never be detected. The window defaults wide (1s)
+    // because on AirPods a fast double-press triggers the OS skip gesture, so
+    // the two play/pause presses must be deliberately spaced out to reach us.
+    const delay = parseInt(localStorage.getItem('playPauseDoubleClickDelay'), 10) || 1000
     if (this._playPauseDoubleClickStarted) {
       clearTimeout(this._playPauseDoubleClickTimer)
       this._playPauseDoubleClickStarted = false
@@ -224,7 +229,7 @@ class Player extends Component {
       this._playPauseDoubleClickStarted = true
       this._playPauseDoubleClickTimer = setTimeout(() => {
         this._playPauseDoubleClickStarted = false
-      }, 1000)
+      }, delay)
     }
   }
 

--- a/packages/front/src/Popup.js
+++ b/packages/front/src/Popup.js
@@ -36,7 +36,7 @@ const Popup = ({
   openOnHover: openOnHoverProp,
   popupAbove
 }) => {
-  const openOnHover = openOnHoverProp || !isMobile
+  const openOnHover = openOnHoverProp === undefined ? !isMobile : openOnHoverProp
   const [open, setOpen] = useState(defaultOpen)
   useEffect(
     (props) => {

--- a/packages/front/src/Settings.js
+++ b/packages/front/src/Settings.js
@@ -151,6 +151,7 @@ class Settings extends Component {
       mediaButtonBehavior: localStorage.getItem('mediaButtonBehavior') || 'seek',
       playPauseAddToCart: (localStorage.getItem('playPauseDoubleClickAddToCart') || 'true') === 'true',
       playPauseAddToCartDelay: parseInt(localStorage.getItem('playPauseDoubleClickDelay'), 10) || 1000,
+      playPauseAddToCartCartId: localStorage.getItem('playPauseDoubleClickCartId') || '',
       audioSamples: [],
       uploadingAudioSample: false,
       deletingAudioSample: null,
@@ -1641,8 +1642,8 @@ class Settings extends Component {
               <h4>Add to cart with play/pause</h4>
               <p>
                 When enabled, pressing the play/pause media button (keyboard, headphones, etc.) twice within the
-                configured delay adds the currently playing track to your default cart. This setting is stored on this
-                device, so it can be configured separately for each device you use.
+                configured delay adds the currently playing track to the selected cart. These settings are stored on
+                this device, so they can be configured separately for each device you use.
               </p>
               <p style={{ display: 'flex', alignItems: 'center', gap: 16 }} className="input-layout">
                 <label htmlFor="play-pause-add-to-cart" className="noselect">
@@ -1659,26 +1660,54 @@ class Settings extends Component {
                 <span className="noselect">{this.state.playPauseAddToCart ? 'On' : 'Off'}</span>
               </p>
               {this.state.playPauseAddToCart ? (
-                <p style={{ display: 'flex', alignItems: 'center', gap: 16 }} className="input-layout">
-                  <label htmlFor="play-pause-add-to-cart-delay" className="noselect">
-                    Maximum delay between presses (ms):
-                  </label>
-                  <input
-                    id="play-pause-add-to-cart-delay"
-                    type="number"
-                    min="100"
-                    step="100"
-                    value={this.state.playPauseAddToCartDelay}
-                    onChange={(e) => {
-                      const value = e.target.value
-                      this.setState({ playPauseAddToCartDelay: value })
-                      const parsed = parseInt(value, 10)
-                      if (!Number.isNaN(parsed) && parsed >= 100) {
-                        localStorage.setItem('playPauseDoubleClickDelay', String(parsed))
-                      }
-                    }}
-                  />
-                </p>
+                <>
+                  <p style={{ display: 'flex', alignItems: 'center', gap: 16 }} className="input-layout">
+                    <label htmlFor="play-pause-add-to-cart-cart" className="noselect">
+                      Add tracks to cart:
+                    </label>
+                    <select
+                      id="play-pause-add-to-cart-cart"
+                      value={this.state.playPauseAddToCartCartId}
+                      onChange={(e) => {
+                        const cartId = e.target.value
+                        if (cartId) {
+                          localStorage.setItem('playPauseDoubleClickCartId', cartId)
+                        } else {
+                          localStorage.removeItem('playPauseDoubleClickCartId')
+                        }
+                        this.setState({ playPauseAddToCartCartId: cartId })
+                      }}
+                    >
+                      <option value="">Default cart</option>
+                      {this.props.carts.map(({ id, name, is_default }) => (
+                        <option key={id} value={id}>
+                          {name}
+                          {is_default ? ' (default)' : ''}
+                        </option>
+                      ))}
+                    </select>
+                  </p>
+                  <p style={{ display: 'flex', alignItems: 'center', gap: 16 }} className="input-layout">
+                    <label htmlFor="play-pause-add-to-cart-delay" className="noselect">
+                      Maximum delay between presses (ms):
+                    </label>
+                    <input
+                      id="play-pause-add-to-cart-delay"
+                      type="number"
+                      min="100"
+                      step="100"
+                      value={this.state.playPauseAddToCartDelay}
+                      onChange={(e) => {
+                        const value = e.target.value
+                        this.setState({ playPauseAddToCartDelay: value })
+                        const parsed = parseInt(value, 10)
+                        if (!Number.isNaN(parsed) && parsed >= 100) {
+                          localStorage.setItem('playPauseDoubleClickDelay', String(parsed))
+                        }
+                      }}
+                    />
+                  </p>
+                </>
               ) : null}
             </>
           ) : null}

--- a/packages/front/src/Settings.js
+++ b/packages/front/src/Settings.js
@@ -149,6 +149,8 @@ class Settings extends Component {
       cartNameEditorValue: '',
       cloningCartId: null,
       mediaButtonBehavior: localStorage.getItem('mediaButtonBehavior') || 'seek',
+      playPauseAddToCart: (localStorage.getItem('playPauseDoubleClickAddToCart') || 'true') === 'true',
+      playPauseAddToCartDelay: parseInt(localStorage.getItem('playPauseDoubleClickDelay'), 10) || 1000,
       audioSamples: [],
       uploadingAudioSample: false,
       deletingAudioSample: null,
@@ -607,20 +609,6 @@ class Settings extends Component {
               </label>
               <input
                 type="radio"
-                id="settings-state-sorting"
-                name="settings-state"
-                checked={this.state.page === 'sorting'}
-                onChange={() => this.onShowPage('sorting')}
-              />
-              <label
-                className="select_button-button  select_button-button__large"
-                htmlFor="settings-state-sorting"
-                data-help-id="sorting-tab"
-              >
-                Sorting
-              </label>
-              <input
-                type="radio"
                 id="settings-state-carts"
                 name="settings-state"
                 checked={this.state.page === 'carts'}
@@ -649,6 +637,20 @@ class Settings extends Component {
               </label>
               <input
                 type="radio"
+                id="settings-state-player"
+                name="settings-state"
+                checked={this.state.page === 'player'}
+                onChange={() => this.onShowPage('player')}
+              />
+              <label
+                className="select_button-button select_button-button__large"
+                htmlFor="settings-state-player"
+                data-help-id="player-tab"
+              >
+                Player
+              </label>
+              <input
+                type="radio"
                 id="settings-state-ignores"
                 name="settings-state"
                 checked={this.state.page === 'ignores'}
@@ -660,6 +662,20 @@ class Settings extends Component {
                 data-help-id="ignores-tab"
               >
                 Ignores
+              </label>
+              <input
+                type="radio"
+                id="settings-state-sorting"
+                name="settings-state"
+                checked={this.state.page === 'sorting'}
+                onChange={() => this.onShowPage('sorting')}
+              />
+              <label
+                className="select_button-button  select_button-button__large"
+                htmlFor="settings-state-sorting"
+                data-help-id="sorting-tab"
+              >
+                Sorting
               </label>
               <input
                 type="radio"
@@ -693,20 +709,6 @@ class Settings extends Component {
                   </label>
                 </>
               )}
-              <input
-                type="radio"
-                id="settings-state-player"
-                name="settings-state"
-                checked={this.state.page === 'player'}
-                onChange={() => this.onShowPage('player')}
-              />
-              <label
-                className="select_button-button select_button-button__large"
-                htmlFor="settings-state-player"
-                data-help-id="player-tab"
-              >
-                Player
-              </label>
             </div>
           </div>
           {this.state.page === 'following' ? (
@@ -1636,6 +1638,48 @@ class Settings extends Component {
                 />
                 <span className="noselect">{this.state.mediaButtonBehavior === 'skip' ? 'Skip' : 'Seek'}</span>
               </p>
+              <h4>Add to cart with play/pause</h4>
+              <p>
+                When enabled, pressing the play/pause media button (keyboard, headphones, etc.) twice within the
+                configured delay adds the currently playing track to your default cart. This setting is stored on this
+                device, so it can be configured separately for each device you use.
+              </p>
+              <p style={{ display: 'flex', alignItems: 'center', gap: 16 }} className="input-layout">
+                <label htmlFor="play-pause-add-to-cart" className="noselect">
+                  Add to cart on double press:
+                </label>
+                <ToggleButton
+                  id="play-pause-add-to-cart"
+                  checked={this.state.playPauseAddToCart}
+                  onChange={(state) => {
+                    localStorage.setItem('playPauseDoubleClickAddToCart', state ? 'true' : 'false')
+                    this.setState({ playPauseAddToCart: state })
+                  }}
+                />
+                <span className="noselect">{this.state.playPauseAddToCart ? 'On' : 'Off'}</span>
+              </p>
+              {this.state.playPauseAddToCart ? (
+                <p style={{ display: 'flex', alignItems: 'center', gap: 16 }} className="input-layout">
+                  <label htmlFor="play-pause-add-to-cart-delay" className="noselect">
+                    Maximum delay between presses (ms):
+                  </label>
+                  <input
+                    id="play-pause-add-to-cart-delay"
+                    type="number"
+                    min="100"
+                    step="100"
+                    value={this.state.playPauseAddToCartDelay}
+                    onChange={(e) => {
+                      const value = e.target.value
+                      this.setState({ playPauseAddToCartDelay: value })
+                      const parsed = parseInt(value, 10)
+                      if (!Number.isNaN(parsed) && parsed >= 100) {
+                        localStorage.setItem('playPauseDoubleClickDelay', String(parsed))
+                      }
+                    }}
+                  />
+                </p>
+              ) : null}
             </>
           ) : null}
           {this.state.page === 'integrations' ? (

--- a/packages/front/src/Settings.js
+++ b/packages/front/src/Settings.js
@@ -15,6 +15,7 @@ import { apiURL } from './config'
 import ExternalLink from './ExternalLink'
 import Onboarding from './Onboarding'
 import { SettingsHelp } from './SettingsHelp'
+import { CartSelectorDropDownButton } from './CartSelectorDropDownButton'
 import ImportPlaylistButton from './ImportPlaylistButton'
 import FollowedItem from './FollowedItem'
 import SearchBar from './SearchBar'
@@ -1662,14 +1663,11 @@ class Settings extends Component {
               {this.state.playPauseAddToCart ? (
                 <>
                   <p style={{ display: 'flex', alignItems: 'center', gap: 16 }} className="input-layout">
-                    <label htmlFor="play-pause-add-to-cart-cart" className="noselect">
-                      Add tracks to cart:
-                    </label>
-                    <select
-                      id="play-pause-add-to-cart-cart"
-                      value={this.state.playPauseAddToCartCartId}
-                      onChange={(e) => {
-                        const cartId = e.target.value
+                    <label className="noselect">Add tracks to cart:</label>
+                    <CartSelectorDropDownButton
+                      carts={this.props.carts}
+                      selectedCartId={this.state.playPauseAddToCartCartId}
+                      onSelectCart={(cartId) => {
                         if (cartId) {
                           localStorage.setItem('playPauseDoubleClickCartId', cartId)
                         } else {
@@ -1677,16 +1675,12 @@ class Settings extends Component {
                         }
                         this.setState({ playPauseAddToCartCartId: cartId })
                       }}
-                    >
-                      <option value="">Default cart</option>
-                      {this.props.carts
-                        .filter(({ is_default }) => !is_default)
-                        .map(({ id, name }) => (
-                          <option key={id} value={id}>
-                            {name}
-                          </option>
-                        ))}
-                    </select>
+                      onCreateCartClick={async (name) => {
+                        const created = await this.props.onCreateCart(name)
+                        await this.props.onUpdateCarts()
+                        return created
+                      }}
+                    />
                   </p>
                   <p style={{ display: 'flex', alignItems: 'center', gap: 16 }} className="input-layout">
                     <label htmlFor="play-pause-add-to-cart-delay" className="noselect">

--- a/packages/front/src/Settings.js
+++ b/packages/front/src/Settings.js
@@ -1679,12 +1679,13 @@ class Settings extends Component {
                       }}
                     >
                       <option value="">Default cart</option>
-                      {this.props.carts.map(({ id, name, is_default }) => (
-                        <option key={id} value={id}>
-                          {name}
-                          {is_default ? ' (default)' : ''}
-                        </option>
-                      ))}
+                      {this.props.carts
+                        .filter(({ is_default }) => !is_default)
+                        .map(({ id, name }) => (
+                          <option key={id} value={id}>
+                            {name}
+                          </option>
+                        ))}
                     </select>
                   </p>
                   <p style={{ display: 'flex', alignItems: 'center', gap: 16 }} className="input-layout">

--- a/packages/front/src/SettingsHelp.js
+++ b/packages/front/src/SettingsHelp.js
@@ -24,19 +24,6 @@ export class SettingsHelp extends Component {
         </>
       ),
     },
-    Sorting: {
-      target: '[data-help-id=sorting-tab]',
-      placement: 'bottom',
-      content: (
-        <p>
-          In the sorting tab you can control how the tracks are sorted in the new tracks list. By adjusting the
-          parameters you can e.g. focus less on the newest tracks by lowering the penalties or ensure the followed
-          artists and labels appear higher in the list by increasing the bonuses. By marking tracks purchased (last item
-          in the add to cart dropdown) and increasing the related bonuses, you can ensure the new releases from the
-          artists and labels appear higher in the list.
-        </p>
-      ),
-    },
     Carts: {
       target: '[data-help-id=carts-tab]',
       placement: 'bottom',
@@ -61,6 +48,18 @@ export class SettingsHelp extends Component {
         </p>
       ),
     },
+    Player: {
+      target: '[data-help-id=player-tab]',
+      placement: 'bottom',
+      content: (
+        <p>
+          In the player tab you can configure the behavior of the media buttons on your device. You can choose between
+          the default behavior (single press to seek, double press to skip) and a skip behavior (single press to skip to
+          the next track or to the beginning/previous track). You can also enable adding the currently playing track to
+          your default cart by pressing play/pause twice, and adjust the maximum delay allowed between the two presses.
+        </p>
+      ),
+    },
     Ignores: {
       target: '[data-help-id=ignores-tab]',
       placement: 'bottom',
@@ -71,6 +70,19 @@ export class SettingsHelp extends Component {
           unwanted tracks in your new tracks list. Fortunately, artists with the same name usually don't release tracks
           on the same label. To reduce noise, use the ignore button to filter artists by labels you are not interested
           in. Manage these preferences in the Ignores tab.
+        </p>
+      ),
+    },
+    Sorting: {
+      target: '[data-help-id=sorting-tab]',
+      placement: 'bottom',
+      content: (
+        <p>
+          In the sorting tab you can control how the tracks are sorted in the new tracks list. By adjusting the
+          parameters you can e.g. focus less on the newest tracks by lowering the penalties or ensure the followed
+          artists and labels appear higher in the list by increasing the bonuses. By marking tracks purchased (last item
+          in the add to cart dropdown) and increasing the related bonuses, you can ensure the new releases from the
+          artists and labels appear higher in the list.
         </p>
       ),
     },
@@ -93,17 +105,6 @@ export class SettingsHelp extends Component {
           In order to synchronise tracks to Spotify, you will need to authorise the service to give it access rights to
           your Spotify account for creating playlists and synchronising the cart contents with playlists. For safety
           reasons the service will only modify playlists it has created.
-        </p>
-      ),
-    },
-    Player: {
-      target: '[data-help-id=player-tab]',
-      placement: 'bottom',
-      content: (
-        <p>
-          In the player tab you can configure the behavior of the media buttons on your device. You can choose between
-          the default behavior (single click to seek, double click to skip) and a skip behavior (single click to skip
-          to the next track or to the beginning/previous track).
         </p>
       ),
       locale: { last: 'Done' },

--- a/packages/front/src/SettingsHelp.js
+++ b/packages/front/src/SettingsHelp.js
@@ -56,7 +56,8 @@ export class SettingsHelp extends Component {
           In the player tab you can configure the behavior of the media buttons on your device. You can choose between
           the default behavior (single press to seek, double press to skip) and a skip behavior (single press to skip to
           the next track or to the beginning/previous track). You can also enable adding the currently playing track to
-          your default cart by pressing play/pause twice, and adjust the maximum delay allowed between the two presses.
+          a cart of your choice by pressing play/pause twice, and adjust the maximum delay allowed between the two
+          presses.
         </p>
       ),
     },


### PR DESCRIPTION
Add a per-device toggle and delay setting for the play/pause double-press
add-to-cart gesture, mirroring the existing skip/seek media button toggle.
Reorder the settings tabs by expected usage frequency, placing the more
advanced configuration tabs last.

https://claude.ai/code/session_01FPoCKXts5Qvfg1VLw7Up9K

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Double-press Play/Pause can add the current track to a selectable cart with configurable delay and opt-out toggle.
  * New cart selector dropdown UI (create/select default or named cart) and responsive styling.

* **User Interface**
  * Dropdowns now surface open/closed events to callers.
  * Popup hover behavior respects explicit off setting.

* **Documentation**
  * Updated help text for Player settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gadgetmies/fomoplayer/pull/368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->