### PR TITLE
Register findDuplicates job in scheduler

### DIFF
--- a/packages/back/job-scheduling.js
+++ b/packages/back/job-scheduling.js
@@ -29,6 +29,7 @@ const { removeOldSources } = require('./jobs/remove-old-sources')
 const { sendInvites } = require('./jobs/send-invites')
 const refetchBandcampLabelArtists = require('./jobs/refetch-bandcamp-label-artists')
 const detectBandcampArtistNameMismatches = require('./jobs/detect-bandcamp-artist-name-mismatches')
+const { findDuplicates } = require('./jobs/find-duplicates')
 
 const init = async () => {
   await pg.queryAsync(
@@ -191,6 +192,7 @@ SELECT job_name AS name, job_schedule AS schedule, job_enabled AS enabled FROM j
   sendInvites,
   refetchBandcampLabelArtists,
   detectBandcampArtistNameMismatches,
+  findDuplicates,
   ...radiator,
 }
 


### PR DESCRIPTION
## Summary

- Adds the `findDuplicates` job to the job scheduler by importing it and registering it in the jobs list

## Test plan

- Verify CI passes
- Confirm the job scheduler initializes without errors

## Sentry

```sentry-also-resolves
```

https://claude.ai/code/session_018w6SzUXLqFjueMibo7CZW1