### PR TITLE
Add bulk release reassignment and artist URL removal to mislabeled admin

### DIFF
--- a/packages/back/routes/admin/api.js
+++ b/packages/back/routes/admin/api.js
@@ -28,6 +28,7 @@ const {
   getMislabeledEntities,
   getMislabeledEntityTracks,
   reassignTrack,
+  reassignReleaseTracks,
   cleanupMislabeledSource,
   ignoreMislabeledEntity,
   flagMislabeledEntity,
@@ -225,6 +226,10 @@ router.get('/mislabeled/:type/:id/tracks', async ({ params: { type, id } }, res)
 router.post('/mislabeled/reassign', async ({ body }, res) => {
   await reassignTrack(body)
   res.send({ ok: true })
+})
+
+router.post('/mislabeled/reassign-release', async ({ body }, res) => {
+  res.send(await reassignReleaseTracks(body))
 })
 
 router.post('/mislabeled/:type/:id/cleanup', async ({ params: { type, id } }, res) => {

--- a/packages/back/routes/admin/api.js
+++ b/packages/back/routes/admin/api.js
@@ -30,6 +30,7 @@ const {
   reassignTrack,
   reassignReleaseTracks,
   cleanupMislabeledSource,
+  removeArtistUrl,
   ignoreMislabeledEntity,
   flagMislabeledEntity,
   convertArtistToLabel,
@@ -248,6 +249,10 @@ router.post('/mislabeled/:type/:id/flag', async ({ params: { type, id } }, res) 
 
 router.post('/mislabeled/artist/:id/convert-to-label', async ({ params: { id } }, res) => {
   res.send(await convertArtistToLabel(id))
+})
+
+router.post('/mislabeled/artist/:id/remove-url', async ({ params: { id } }, res) => {
+  res.send(await removeArtistUrl(id))
 })
 
 router.post('/labels/:id/refetch-bandcamp-artists', async ({ params: { id } }, res) => {

--- a/packages/back/routes/admin/db.js
+++ b/packages/back/routes/admin/db.js
@@ -1066,6 +1066,10 @@ module.exports.reassignTrack = async ({ sourceType, sourceId, targetType, target
       await tx.queryAsync(sql`-- reassignTrack remove label
         DELETE FROM track__label WHERE track_id = ${track} AND label_id = ${src}`)
     }
+
+    // Rebuild the cached track_details JSON so search reflects the new credit
+    // instead of the old one.
+    await refreshTrackDetails(tx, [track])
   })
 
   // Revert by removing the added {targetType targetId} link from track ${track}
@@ -1093,6 +1097,7 @@ module.exports.reassignReleaseTracks = async ({ sourceType, sourceId, targetType
   if (sourceType === targetType && src === tgt) throw new Error('Source and target are the same entity')
 
   let reassigned = 0
+  const reassignedTrackIds = []
   await BPromise.using(pg.getTransaction(), async (tx) => {
     const tracks =
       sourceType === 'artist'
@@ -1133,8 +1138,13 @@ module.exports.reassignReleaseTracks = async ({ sourceType, sourceId, targetType
         await tx.queryAsync(sql`-- reassignReleaseTracks remove label
           DELETE FROM track__label WHERE track_id = ${trackId} AND label_id = ${src}`)
       }
+      reassignedTrackIds.push(trackId)
       reassigned++
     }
+
+    // Rebuild the cached track_details JSON so search reflects the new credits
+    // instead of the old ones.
+    await refreshTrackDetails(tx, reassignedTrackIds)
   })
 
   logger.info(`reassignReleaseTracks: release ${rel} ${sourceType} ${src} -> ${targetType} ${tgt} (${reassigned} tracks)`, {

--- a/packages/back/routes/admin/db.js
+++ b/packages/back/routes/admin/db.js
@@ -1269,3 +1269,39 @@ module.exports.cleanupMislabeledSource = async (type, id) => {
     return { deleted: false }
   }
 }
+
+// Detach a mislabeled Bandcamp page from an artist without deleting the artist:
+// clear its Bandcamp store URL (so a future import can't re-absorb tracks onto
+// it) and resolve the mislabeled flag, leaving the artist and all its track
+// credits intact. Use when the artist is legitimate but was wrongly linked to a
+// Bandcamp page.
+module.exports.removeArtistUrl = async (id) => {
+  const parsedId = parseInt(id, 10)
+  if (Number.isNaN(parsedId)) throw new Error('Invalid id')
+
+  const storeArtistRowsCleared = await pg.queryRowsAsync(sql`-- removeArtistUrl store__artist before
+    SELECT store__artist_id  AS "storeArtistId"
+         , store__artist_url AS url
+    FROM store__artist
+    WHERE artist_id = ${parsedId}
+      AND store_id = (SELECT store_id FROM store WHERE store_url = ${BANDCAMP_STORE_URL})
+      AND store__artist_url IS NOT NULL`)
+
+  await BPromise.using(pg.getTransaction(), async (tx) => {
+    await tx.queryAsync(sql`-- removeArtistUrl clear url
+      UPDATE store__artist
+      SET store__artist_url = NULL, store__artist_store_id = NULL
+      WHERE artist_id = ${parsedId}
+        AND store_id = (SELECT store_id FROM store WHERE store_url = ${BANDCAMP_STORE_URL})`)
+    await tx.queryAsync(sql`-- removeArtistUrl clear flag
+      DELETE FROM bandcamp_mislabeled_artist
+      WHERE artist_id = ${parsedId} AND bandcamp_mislabeled_artist_status = 'new'`)
+  })
+
+  logger.info(`removeArtistUrl: cleared Bandcamp URL for artist ${parsedId}`, {
+    operation: 'removeArtistUrl',
+    artistId: parsedId,
+    storeArtistRowsCleared,
+  })
+  return { cleared: storeArtistRowsCleared.length }
+}

--- a/packages/back/routes/admin/db.js
+++ b/packages/back/routes/admin/db.js
@@ -1078,6 +1078,75 @@ module.exports.reassignTrack = async ({ sourceType, sourceId, targetType, target
   })
 }
 
+// Reassign every track of one release that is currently credited to a mislabeled
+// source entity onto the correct target, in a single transaction. Used from the
+// inspect view to re-attribute a whole release at once (e.g. a compilation whose
+// tracks were all collapsed onto the label name). Each track keeps its own role.
+module.exports.reassignReleaseTracks = async ({ sourceType, sourceId, targetType, targetId, releaseId }) => {
+  if (!MISLABELED_ENTITY_TYPES.includes(sourceType) || !MISLABELED_ENTITY_TYPES.includes(targetType)) {
+    throw new Error('Invalid entity type')
+  }
+  const src = parseInt(sourceId, 10)
+  const tgt = parseInt(targetId, 10)
+  const rel = parseInt(releaseId, 10)
+  if ([src, tgt, rel].some((n) => Number.isNaN(n))) throw new Error('Invalid id')
+  if (sourceType === targetType && src === tgt) throw new Error('Source and target are the same entity')
+
+  let reassigned = 0
+  await BPromise.using(pg.getTransaction(), async (tx) => {
+    const tracks =
+      sourceType === 'artist'
+        ? await tx.queryRowsAsync(sql`-- reassignReleaseTracks find artist tracks
+            SELECT ta.track_id AS "trackId", ta.track__artist_role AS role
+            FROM release__track rt
+              JOIN track__artist ta ON ta.track_id = rt.track_id
+            WHERE rt.release_id = ${rel} AND ta.artist_id = ${src}`)
+        : await tx.queryRowsAsync(sql`-- reassignReleaseTracks find label tracks
+            SELECT tl.track_id AS "trackId", NULL AS role
+            FROM release__track rt
+              JOIN track__label tl ON tl.track_id = rt.track_id
+            WHERE rt.release_id = ${rel} AND tl.label_id = ${src}`)
+
+    for (const { trackId, role } of tracks) {
+      const targetRole = targetType === 'artist' ? role || 'author' : null
+      if (targetType === 'artist') {
+        await tx.queryAsync(sql`-- reassignReleaseTracks add artist
+          INSERT INTO track__artist (track_id, artist_id, track__artist_role)
+          VALUES (${trackId}, ${tgt}, ${targetRole})
+          ON CONFLICT ON CONSTRAINT track__artist_track_id_artist_id_track__artist_role_key DO NOTHING`)
+      } else {
+        await tx.queryAsync(sql`-- reassignReleaseTracks add label
+          INSERT INTO track__label (track_id, label_id)
+          VALUES (${trackId}, ${tgt})
+          ON CONFLICT ON CONSTRAINT track__label_track_id_label_id_key DO NOTHING`)
+      }
+
+      if (sourceType === 'artist') {
+        if (role) {
+          await tx.queryAsync(sql`-- reassignReleaseTracks remove artist (role)
+            DELETE FROM track__artist WHERE track_id = ${trackId} AND artist_id = ${src} AND track__artist_role = ${role}`)
+        } else {
+          await tx.queryAsync(sql`-- reassignReleaseTracks remove artist
+            DELETE FROM track__artist WHERE track_id = ${trackId} AND artist_id = ${src}`)
+        }
+      } else {
+        await tx.queryAsync(sql`-- reassignReleaseTracks remove label
+          DELETE FROM track__label WHERE track_id = ${trackId} AND label_id = ${src}`)
+      }
+      reassigned++
+    }
+  })
+
+  logger.info(`reassignReleaseTracks: release ${rel} ${sourceType} ${src} -> ${targetType} ${tgt} (${reassigned} tracks)`, {
+    operation: 'reassignReleaseTracks',
+    releaseId: rel,
+    reassigned,
+    added: { type: targetType, id: tgt },
+    removed: { type: sourceType, id: src },
+  })
+  return { reassigned }
+}
+
 // After reassigning, neutralise the source: clear the bogus Bandcamp store URL
 // (artists only — the label URL is NOT NULL) so it can't re-absorb, then delete
 // it if nothing references it anymore.

--- a/packages/front/src/AdminMislabeled.css
+++ b/packages/front/src/AdminMislabeled.css
@@ -147,6 +147,23 @@
   max-width: 720px;
 }
 
+.mislabeled-help p {
+  margin: 0 0 6px 0;
+}
+
+.mislabeled-help ul {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.mislabeled-help li {
+  margin-bottom: 4px;
+}
+
+.mislabeled-help strong {
+  color: #ccc;
+}
+
 .mislabeled-list-heading {
   margin: 8px 0 4px 0;
 }

--- a/packages/front/src/AdminMislabeled.css
+++ b/packages/front/src/AdminMislabeled.css
@@ -131,6 +131,51 @@
   border-bottom: 1px solid #444;
 }
 
+.mislabeled-flag-text {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+  min-width: 240px;
+}
+
+.mislabeled-help {
+  color: #aaa;
+  font-size: 0.85em;
+  line-height: 1.4;
+  margin: 0 0 8px 0;
+  max-width: 720px;
+}
+
+.mislabeled-list-heading {
+  margin: 8px 0 4px 0;
+}
+
+.mislabeled-release-group {
+  margin-bottom: 18px;
+}
+
+.mislabeled-release-header {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+  padding: 8px;
+  background: #2a2a2a;
+  border-radius: 4px 4px 0 0;
+}
+
+.mislabeled-release-reassign {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-left: auto;
+}
+
+.mislabeled-release-reassign > span {
+  font-size: 0.9em;
+}
+
 .mislabeled-mismatches {
   margin-bottom: 16px;
   padding-bottom: 16px;

--- a/packages/front/src/AdminMislabeled.js
+++ b/packages/front/src/AdminMislabeled.js
@@ -415,6 +415,29 @@ function AdminMislabeled() {
     }
   }
 
+  const removeUrl = async () => {
+    if (
+      !window.confirm(
+        `Remove the Bandcamp URL from artist "${selected.name}" (${selected.id})? The artist and all its tracks are kept; only its link to the Bandcamp page is cleared so a future import won't re-absorb tracks onto it.`,
+      )
+    )
+      return
+    setProcessing(true)
+    try {
+      await requestJSONwithCredentials({
+        url: `${apiURL}/admin/mislabeled/artist/${selected.id}/remove-url`,
+        method: 'POST',
+      })
+      window.alert('Bandcamp URL removed from the artist.')
+      await fetchEntities(type)
+    } catch (e) {
+      console.error(e)
+      window.alert('Could not remove the URL')
+    } finally {
+      setProcessing(false)
+    }
+  }
+
   const renderList = () => (
     <div className="mislabeled-list">
       {convertedLabel && (
@@ -574,6 +597,16 @@ function AdminMislabeled() {
                 Convert to label
               </button>
             )}
+            {type === 'artist' && (
+              <button
+                type="button"
+                disabled={processing}
+                onClick={removeUrl}
+                title="Clear just this artist's Bandcamp page URL while keeping the artist and all its tracks. Use when the artist is legitimate but was wrongly linked to a Bandcamp page."
+              >
+                Remove URL from artist
+              </button>
+            )}
             <button
               type="button"
               disabled={processing}
@@ -608,6 +641,13 @@ function AdminMislabeled() {
                 <strong>Convert to label</strong>: use when this “artist” is really a label whose releases are by various
                 artists. Turns it into a label, moves its followers across, retires the artist, and queues a re-fetch so
                 each track is re-credited to its real artist.
+              </li>
+            )}
+            {type === 'artist' && (
+              <li>
+                <strong>Remove URL from artist</strong>: clears just this artist’s Bandcamp page URL (so a future import
+                won’t re-absorb tracks onto it) while keeping the artist and all its track credits. Use when the artist
+                is legitimate but was wrongly linked to a Bandcamp page.
               </li>
             )}
             <li>

--- a/packages/front/src/AdminMislabeled.js
+++ b/packages/front/src/AdminMislabeled.js
@@ -565,27 +565,59 @@ function AdminMislabeled() {
           </div>
           <div className="mislabeled-actions">
             {type === 'artist' && (
-              <button type="button" disabled={processing} onClick={convertToLabel}>
+              <button
+                type="button"
+                disabled={processing}
+                onClick={convertToLabel}
+                title="Turn this artist into a label of the same name: re-credit every track to the label, move its followers across, retire the artist, and queue a re-fetch so tracks are re-attributed to their real per-track artists."
+              >
                 Convert to label
               </button>
             )}
-            <button type="button" disabled={processing} onClick={cleanup}>
+            <button
+              type="button"
+              disabled={processing}
+              onClick={cleanup}
+              title="Clear this entity's bogus Bandcamp URL so a future import can't re-absorb tracks onto it, then delete it entirely if nothing references it anymore (no tracks and no followers left). Run it after reassigning its tracks away."
+            >
               Clean up source
             </button>
-            <button type="button" disabled={processing} onClick={() => setSelected(null)}>
+            <button
+              type="button"
+              disabled={processing}
+              onClick={() => setSelected(null)}
+              title="Return to the list without making changes."
+            >
               Back to list
             </button>
           </div>
         </div>
-        <p className="mislabeled-help">
-          Each track below is currently credited to this {type}. Use “Reassign to” on a single track, or “Reassign all
-          tracks to” in a release’s header to move a whole release at once, to pick the artist or label it should really
-          belong to: the track gains the chosen credit and loses this one. Once no tracks remain, use “Clean up source”
-          to clear this {type}’s bogus Bandcamp URL and delete it if it is now empty.
-          {type === 'artist'
-            ? ' Use “Convert to label” when this is really a label whose releases are by various artists — it turns the artist into a label, moves followers across and queues a re-fetch so each track is re-credited to its real artist.'
-            : ''}
-        </p>
+        <div className="mislabeled-help">
+          <p>
+            Each track below is currently credited to this {type}. Reassign the ones that belong elsewhere, then tidy up
+            this source:
+          </p>
+          <ul>
+            <li>
+              <strong>Reassign to</strong> (single track) / <strong>Reassign all tracks to</strong> (whole release):
+              moves the track(s) to the artist or label they really belong to — each track gains the chosen credit and
+              loses this one.
+            </li>
+            {type === 'artist' && (
+              <li>
+                <strong>Convert to label</strong>: use when this “artist” is really a label whose releases are by various
+                artists. Turns it into a label, moves its followers across, retires the artist, and queues a re-fetch so
+                each track is re-credited to its real artist.
+              </li>
+            )}
+            <li>
+              <strong>Clean up source</strong>: clears this {type}’s bogus Bandcamp URL (so a future import won’t
+              re-absorb tracks onto it) and deletes the {type} entirely if nothing references it anymore — i.e. it has no
+              tracks and no followers left; otherwise the {type} is kept with its URL cleared. Run it after you’ve
+              reassigned its tracks away.
+            </li>
+          </ul>
+        </div>
 
         {tracksLoading ? (
           <div>Loading tracks…</div>

--- a/packages/front/src/AdminMislabeled.js
+++ b/packages/front/src/AdminMislabeled.js
@@ -15,6 +15,25 @@ const REASON_LABELS = {
 
 const formatArtists = (artists) => (artists && artists.length ? artists.map((a) => `${a.name} (${a.role})`).join(', ') : '—')
 
+// Group a flat track list (from the inspect endpoint) by release, preserving
+// order, so the detail view can offer a per-release bulk reassignment. Tracks
+// with no release fall into a trailing group keyed by `null`.
+const groupTracksByRelease = (tracks) => {
+  const groups = []
+  const byReleaseId = new Map()
+  tracks.forEach((track) => {
+    const key = track.releaseId == null ? null : track.releaseId
+    let group = byReleaseId.get(key)
+    if (!group) {
+      group = { releaseId: track.releaseId ?? null, releaseName: track.releaseName, releaseUrl: track.releaseUrl, tracks: [] }
+      byReleaseId.set(key, group)
+      groups.push(group)
+    }
+    group.tracks.push(track)
+  })
+  return groups
+}
+
 // Render text as a link to its Bandcamp page when a URL is known, otherwise the
 // bare text — used wherever the view names an artist, label, release or track.
 const BandcampLink = ({ url, children }) =>
@@ -176,6 +195,32 @@ function AdminMislabeled() {
         body: { sourceType: type, sourceId: selected.id, targetType, targetId, trackId: track.id, role: track.role },
       })
       setTracks((prev) => prev.filter((t) => t.id !== track.id))
+    } catch (e) {
+      console.error(e)
+      window.alert('Reassign failed')
+    } finally {
+      setProcessing(false)
+    }
+  }
+
+  const reassignRelease = async (group, { targetType, targetId, targetName }) => {
+    if (
+      !window.confirm(
+        `Reassign all ${group.tracks.length} track${group.tracks.length === 1 ? '' : 's'} of "${
+          group.releaseName || group.releaseUrl || 'this release'
+        }" from ${type} "${selected.name}" to ${targetType} "${targetName}" (${targetId})?`,
+      )
+    )
+      return
+    setProcessing(true)
+    try {
+      await requestJSONwithCredentials({
+        url: `${apiURL}/admin/mislabeled/reassign-release`,
+        method: 'POST',
+        body: { sourceType: type, sourceId: selected.id, targetType, targetId, releaseId: group.releaseId },
+      })
+      const reassignedIds = new Set(group.tracks.map((t) => t.id))
+      setTracks((prev) => prev.filter((t) => !reassignedIds.has(t.id)))
     } catch (e) {
       console.error(e)
       window.alert('Reassign failed')
@@ -387,30 +432,56 @@ function AdminMislabeled() {
         </div>
       )}
       <div className="mislabeled-flag">
-        <span>Flag a {type} as mislabeled:</span>
+        <div className="mislabeled-flag-text">
+          <span>Flag a {type} as mislabeled:</span>
+          <p className="mislabeled-help">
+            Adds the chosen {type} to the review list below. This only flags it — its tracks and pages are left
+            untouched until you Inspect it and reassign its tracks{' '}
+            {type === 'artist' ? '(or Convert it to a label if it is really a label)' : ''}.
+          </p>
+        </div>
         <EntityPicker fixedType={type} processing={processing} onPick={flagEntity} />
       </div>
       <div className="mislabeled-flag">
-        <span>Fix a wrongly credited Bandcamp artist (re-point its pages, re-attribute tracks):</span>
+        <div className="mislabeled-flag-text">
+          <span>Fix an artist that is really a label:</span>
+          <p className="mislabeled-help">
+            Use this when a Bandcamp page was imported as an artist but is actually a label whose releases are by
+            various artists. Converts every matching Bandcamp page held by the chosen artist into a label and queues a
+            background re-fetch so each track is re-credited to its real per-track artist (instead of the label name).
+          </p>
+        </div>
         <EntityPicker fixedType="artist" processing={processing} onPick={fixArtistMismatches} />
       </div>
       <div className="mislabeled-flag">
-        <span>Fix a Bandcamp artist page by URL:</span>
-        <input
-          type="text"
-          value={fixUrl}
-          placeholder="https://artist.bandcamp.com/"
-          disabled={processing}
-          onChange={(e) => setFixUrl(e.target.value)}
-          style={{ minWidth: 280 }}
-        />
+        <div className="mislabeled-flag-text">
+          <span>Fix a Bandcamp page by URL:</span>
+          <p className="mislabeled-help">
+            The same fix as above, but targeted at one Bandcamp page by its URL. Looks up that page; if it is really a
+            label, converts it into a label and queues a re-fetch to re-attribute its tracks to their real artists.
+          </p>
+          <input
+            type="text"
+            value={fixUrl}
+            placeholder="https://label.bandcamp.com/"
+            disabled={processing}
+            onChange={(e) => setFixUrl(e.target.value)}
+            style={{ minWidth: 280 }}
+          />
+        </div>
         <button type="button" disabled={processing || !fixUrl.trim()} onClick={fixByUrl}>
-          Fix page
+          Fix Bandcamp page
         </button>
       </div>
       {mismatches.length > 0 && (
         <div className="mislabeled-mismatches">
           <h6>Suspected wrong artist mappings ({mismatches.length})</h6>
+          <p className="mislabeled-help">
+            Bandcamp pages imported as artists whose name barely matches their subdomain — usually label pages whose
+            releases were collapsed onto a single artist. For each row, “Fix” converts that page into a label and queues
+            a re-fetch so its tracks are re-attributed to their real artists; “Ignore” dismisses the suggestion so it
+            won’t be flagged again.
+          </p>
           {mismatches.map((m) => (
             <div key={m.storeArtistId} className="mislabeled-item">
               <div className="mislabeled-info">
@@ -438,6 +509,12 @@ function AdminMislabeled() {
           ))}
         </div>
       )}
+      <h6 className="mislabeled-list-heading">Suspected mislabeled {type}s ({entities.length})</h6>
+      <p className="mislabeled-help">
+        These are the {type}s detected as mislabeled (the reason is shown on each row). “Inspect” opens the {type} and
+        lists every track credited to it so you can reassign them to the right artist or label; “Ignore” hides this row
+        until it is detected again.
+      </p>
       {entities.length === 0 && <div>No suspected mislabeled {type}s found.</div>}
       {entities.map((entity) => (
         <div key={entity.id} className="mislabeled-item">
@@ -471,70 +548,100 @@ function AdminMislabeled() {
     </div>
   )
 
-  const renderDetail = () => (
-    <div className="mislabeled-detail">
-      <div className="mislabeled-detail-header">
-        <div>
-          <h2>
-            {type === 'artist' ? 'Artist' : 'Label'}:{' '}
-            <BandcampLink url={selected.url}>{selected.name}</BandcampLink>{' '}
-            <span className="muted">({selected.id})</span>
-          </h2>
-          <div className="muted mislabeled-url">
-            <BandcampLink url={selected.url}>{selected.url}</BandcampLink>
+  const renderDetail = () => {
+    const groups = groupTracksByRelease(tracks)
+    return (
+      <div className="mislabeled-detail">
+        <div className="mislabeled-detail-header">
+          <div>
+            <h2>
+              {type === 'artist' ? 'Artist' : 'Label'}:{' '}
+              <BandcampLink url={selected.url}>{selected.name}</BandcampLink>{' '}
+              <span className="muted">({selected.id})</span>
+            </h2>
+            <div className="muted mislabeled-url">
+              <BandcampLink url={selected.url}>{selected.url}</BandcampLink>
+            </div>
+          </div>
+          <div className="mislabeled-actions">
+            {type === 'artist' && (
+              <button type="button" disabled={processing} onClick={convertToLabel}>
+                Convert to label
+              </button>
+            )}
+            <button type="button" disabled={processing} onClick={cleanup}>
+              Clean up source
+            </button>
+            <button type="button" disabled={processing} onClick={() => setSelected(null)}>
+              Back to list
+            </button>
           </div>
         </div>
-        <div className="mislabeled-actions">
-          {type === 'artist' && (
-            <button type="button" disabled={processing} onClick={convertToLabel}>
-              Convert to label
-            </button>
-          )}
-          <button type="button" disabled={processing} onClick={cleanup}>
-            Clean up source
-          </button>
-          <button type="button" disabled={processing} onClick={() => setSelected(null)}>
-            Back to list
-          </button>
-        </div>
-      </div>
+        <p className="mislabeled-help">
+          Each track below is currently credited to this {type}. Use “Reassign to” on a single track, or “Reassign all
+          tracks to” in a release’s header to move a whole release at once, to pick the artist or label it should really
+          belong to: the track gains the chosen credit and loses this one. Once no tracks remain, use “Clean up source”
+          to clear this {type}’s bogus Bandcamp URL and delete it if it is now empty.
+          {type === 'artist'
+            ? ' Use “Convert to label” when this is really a label whose releases are by various artists — it turns the artist into a label, moves followers across and queues a re-fetch so each track is re-credited to its real artist.'
+            : ''}
+        </p>
 
-      {tracksLoading ? (
-        <div>Loading tracks…</div>
-      ) : tracks.length === 0 ? (
-        <div>No tracks remain attributed to this {type}. You can clean up the source now.</div>
-      ) : (
-        <table className="mislabeled-tracks">
-          <thead>
-            <tr>
-              <th>Track</th>
-              <th>Release</th>
-              <th>Current credits</th>
-              <th>Reassign to</th>
-            </tr>
-          </thead>
-          <tbody>
-            {tracks.map((track) => (
-              <tr key={track.id}>
-                <td>
-                  <BandcampLink url={track.trackUrl}>{track.title}</BandcampLink>
-                  {track.version ? ` (${track.version})` : ''}
-                  {track.role ? <span className="muted"> · {track.role}</span> : null}
-                </td>
-                <td>
-                  <BandcampLink url={track.releaseUrl}>{track.releaseName || track.releaseUrl || '—'}</BandcampLink>
-                </td>
-                <td className="muted">{formatArtists(track.artists)}</td>
-                <td>
-                  <EntityPicker processing={processing} onPick={(target) => reassign(track, target)} />
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
-    </div>
-  )
+        {tracksLoading ? (
+          <div>Loading tracks…</div>
+        ) : tracks.length === 0 ? (
+          <div>No tracks remain attributed to this {type}. You can clean up the source now.</div>
+        ) : (
+          groups.map((group) => (
+            <div className="mislabeled-release-group" key={group.releaseId == null ? 'none' : group.releaseId}>
+              <div className="mislabeled-release-header">
+                <strong>
+                  Release: <BandcampLink url={group.releaseUrl}>{group.releaseName || group.releaseUrl || '—'}</BandcampLink>{' '}
+                  <span className="muted">
+                    ({group.tracks.length} track{group.tracks.length === 1 ? '' : 's'})
+                  </span>
+                </strong>
+                {group.releaseId != null && (
+                  <label className="mislabeled-release-reassign">
+                    <span>Reassign all tracks to:</span>
+                    <EntityPicker
+                      fixedType="artist"
+                      processing={processing}
+                      onPick={(target) => reassignRelease(group, target)}
+                    />
+                  </label>
+                )}
+              </div>
+              <table className="mislabeled-tracks">
+                <thead>
+                  <tr>
+                    <th>Track</th>
+                    <th>Current credits</th>
+                    <th>Reassign to</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {group.tracks.map((track) => (
+                    <tr key={track.id}>
+                      <td>
+                        <BandcampLink url={track.trackUrl}>{track.title}</BandcampLink>
+                        {track.version ? ` (${track.version})` : ''}
+                        {track.role ? <span className="muted"> · {track.role}</span> : null}
+                      </td>
+                      <td className="muted">{formatArtists(track.artists)}</td>
+                      <td>
+                        <EntityPicker processing={processing} onPick={(target) => reassign(track, target)} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ))
+        )}
+      </div>
+    )
+  }
 
   return (
     <div className="page-container scroll-container admin-mislabeled">


### PR DESCRIPTION
## Summary

- Add ability to reassign all tracks of a release at once from the mislabeled detail view, grouping tracks by release for easier bulk operations
- Add "Remove URL from artist" action to detach a wrongly-linked Bandcamp page from an artist without deleting the artist
- Expand help text throughout the mislabeled admin interface to clarify what each action does and when to use it
- Refactor detail view to display tracks grouped by release with per-release reassignment controls

## Test plan

- Verify the detail view groups tracks by release correctly, with releases appearing in order
- Test bulk reassignment of all tracks in a release to a different artist/label
- Test the "Remove URL from artist" button clears the Bandcamp URL and resolves the mislabeled flag while preserving the artist and its track credits
- Verify help text displays correctly and provides clear guidance on each action
- Confirm single-track reassignment still works as before
- Verify "Clean up source" and "Convert to label" actions still function correctly

## Sentry

```sentry-also-resolves
```

https://claude.ai/code/session_01DyASXbmRBZPSQbUhqrRmbK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bulk reassignment of all tracks within a release to correct artist/label attribution
  * Added ability to remove mislabeled Bandcamp URLs from artists without deleting artist records
  * Enhanced admin interface with release-grouped track management for streamlined operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gadgetmies/fomoplayer/pull/370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->