### PR TITLE
Add admin feature to split combined artists

### DIFF
--- a/packages/back/job-scheduling.js
+++ b/packages/back/job-scheduling.js
@@ -29,6 +29,7 @@ const { removeOldSources } = require('./jobs/remove-old-sources')
 const { sendInvites } = require('./jobs/send-invites')
 const refetchBandcampLabelArtists = require('./jobs/refetch-bandcamp-label-artists')
 const detectBandcampArtistNameMismatches = require('./jobs/detect-bandcamp-artist-name-mismatches')
+const detectArtistSplitCandidates = require('./jobs/detect-artist-split-candidates')
 const { findDuplicates } = require('./jobs/find-duplicates')
 
 const init = async () => {
@@ -200,6 +201,7 @@ SELECT job_name AS name, job_schedule AS schedule, job_enabled AS enabled FROM j
   sendInvites,
   refetchBandcampLabelArtists,
   detectBandcampArtistNameMismatches,
+  detectArtistSplitCandidates,
   findDuplicates,
   ...radiator,
 }

--- a/packages/back/jobs/detect-artist-split-candidates.js
+++ b/packages/back/jobs/detect-artist-split-candidates.js
@@ -1,0 +1,23 @@
+const logger = require('fomoplayer_shared').logger(__filename)
+const { getArtistsForSplitScan, flagArtistSplitCandidate } = require('../routes/shared/db/artistSplit')
+const { hasSplitSeparators, suggestArtistSplit } = require('../routes/admin/artist-split-logic')
+
+// Flag artists whose name looks like it bundles several artists (e.g. a
+// Bandcamp byline "Sleepnet & Lumen" stored as one artist), so an admin can
+// split them into the real individual artists. Detection only; the repair is
+// admin-driven so genuine compound names ("Camo & Krooked") are not split.
+module.exports = async () => {
+  const artists = await getArtistsForSplitScan()
+  let flagged = 0
+
+  for (const { artistId, name } of artists) {
+    if (!hasSplitSeparators(name)) continue
+    const suggestions = suggestArtistSplit(name)
+    if (suggestions.length < 2) continue
+    await flagArtistSplitCandidate({ artistId, name, suggestions })
+    flagged++
+  }
+
+  logger.info(`Artist split candidate scan: ${flagged} flagged of ${artists.length} artists`)
+  return { success: true, result: { scanned: artists.length, flagged } }
+}

--- a/packages/back/migrations/20260524130000-add-artist-split-candidate.js
+++ b/packages/back/migrations/20260524130000-add-artist-split-candidate.js
@@ -1,0 +1,25 @@
+'use strict';
+var fs = require('fs');
+var path = require('path');
+
+function readSql(name) {
+  var filePath = path.join(__dirname, 'sqls', name);
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err);
+      resolve(data);
+    });
+  });
+}
+
+exports.up = function (db) {
+  return readSql('20260524130000-add-artist-split-candidate-up.sql').then(function (data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function (db) {
+  return readSql('20260524130000-add-artist-split-candidate-down.sql').then(function (data) {
+    return db.runSql(data);
+  });
+};

--- a/packages/back/migrations/sqls/20260524130000-add-artist-split-candidate-down.sql
+++ b/packages/back/migrations/sqls/20260524130000-add-artist-split-candidate-down.sql
@@ -1,0 +1,3 @@
+DELETE FROM job_schedule WHERE job_id = (SELECT job_id FROM job WHERE job_name = 'detectArtistSplitCandidates');
+DELETE FROM job WHERE job_name = 'detectArtistSplitCandidates';
+DROP TABLE IF EXISTS artist_split_candidate;

--- a/packages/back/migrations/sqls/20260524130000-add-artist-split-candidate-up.sql
+++ b/packages/back/migrations/sqls/20260524130000-add-artist-split-candidate-up.sql
@@ -1,0 +1,23 @@
+-- Artists whose name looks like it bundles several artists (e.g. "Sleepnet &
+-- Lumen", "Unglued x Whiney", "Camo & Krooked featuring Rezar"), populated by
+-- detectArtistSplitCandidates for admin review. Splitting re-credits the
+-- artist's tracks to the real individual artists and retires the bundle.
+CREATE TABLE artist_split_candidate (
+  artist_split_candidate_id          SERIAL PRIMARY KEY,
+  artist_id                          INTEGER NOT NULL UNIQUE REFERENCES artist (artist_id) ON DELETE CASCADE,
+  artist_split_candidate_name        TEXT NOT NULL,
+  artist_split_candidate_suggestions JSONB NOT NULL DEFAULT '[]',
+  artist_split_candidate_status      TEXT NOT NULL DEFAULT 'new'
+    CHECK (artist_split_candidate_status IN ('new', 'ignored', 'split')),
+  artist_split_candidate_added       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  artist_split_candidate_checked_at  TIMESTAMPTZ
+);
+
+INSERT INTO job (job_name, job_enabled) VALUES ('detectArtistSplitCandidates', TRUE)
+ON CONFLICT (job_name) DO UPDATE SET job_enabled = TRUE;
+
+INSERT INTO job_schedule (job_id, job_schedule)
+SELECT job_id, '0 4 * * *'
+FROM job
+WHERE job_name = 'detectArtistSplitCandidates'
+ON CONFLICT (job_id) DO NOTHING;

--- a/packages/back/routes/admin/api.js
+++ b/packages/back/routes/admin/api.js
@@ -50,8 +50,39 @@ const {
 } = require('./db')
 const { getPreviewDetails } = require('../stores/bandcamp/logic')
 const { ensureIsAdmin } = require('../shared/auth.js')
+const config = require('../../config')
+const { isDatabaseResetAllowed } = require('./database-reset-policy')
+const { resetDatabase, databaseResetEnvironmentName } = require('./reset-database')
 
 router.use(ensureIsAdmin)
+
+// Lets the admin UI decide whether to surface preview-only tools. The database
+// reset is offered only in preview deployments; production never reports it.
+router.get('/capabilities', (req, res) => {
+  const databaseReset = isDatabaseResetAllowed(config)
+  res.send({
+    databaseReset,
+    environmentName: databaseReset ? databaseResetEnvironmentName() : null,
+  })
+})
+
+// Destructive: drops all data and rebuilds an empty schema. Hard-gated to
+// preview environments regardless of the UI, requires the env name as a typed
+// confirmation token, and is the authoritative check (the resetDatabase helper
+// re-asserts the same policy).
+router.post('/reset-database', async (req, res) => {
+  if (!isDatabaseResetAllowed(config)) {
+    return res.status(403).send({ error: 'Database reset is not available in this environment' })
+  }
+  if (req.body?.confirm !== databaseResetEnvironmentName()) {
+    return res.status(400).send({ error: 'Confirmation does not match the environment name' })
+  }
+  // Rebuilding every migration can outlast the global 25s request timeout.
+  if (typeof req.clearTimeout === 'function') req.clearTimeout()
+  logger.warn(`Admin ${req.user?.id ?? 'unknown'} triggered a database reset`)
+  await resetDatabase()
+  res.send({ ok: true })
+})
 router.get('/jobs', async (req, res) => {
   res.send(await getJobs())
 })

--- a/packages/back/routes/admin/api.js
+++ b/packages/back/routes/admin/api.js
@@ -41,6 +41,12 @@ const {
   fixArtistNameMismatch,
   fixBandcampArtistPageByUrl,
   fixArtistBandcampMismatches,
+  getArtistSplitCandidates,
+  ignoreArtistSplitCandidate,
+  getArtistTracks,
+  splitArtist,
+  addArtistCredit,
+  removeArtistCredit,
 } = require('./db')
 const { getPreviewDetails } = require('../stores/bandcamp/logic')
 const { ensureIsAdmin } = require('../shared/auth.js')
@@ -284,6 +290,31 @@ router.post('/bandcamp/fix-artist-page', async ({ body: { url } }, res) => {
 
 router.post('/artists/:id/fix-bandcamp-mismatches', async ({ params: { id } }, res) => {
   res.send(await fixArtistBandcampMismatches(id))
+})
+
+router.get('/artist-split-candidates', async (_, res) => {
+  res.send(await getArtistSplitCandidates())
+})
+
+router.get('/artists/:id/tracks', async ({ params: { id } }, res) => {
+  res.send(await getArtistTracks(id))
+})
+
+router.post('/artist-split-candidates/:id/ignore', async ({ params: { id } }, res) => {
+  await ignoreArtistSplitCandidate(id)
+  res.send({ ok: true })
+})
+
+router.post('/artists/:id/split', async ({ params: { id }, body: { targets } }, res) => {
+  res.send(await splitArtist(id, targets))
+})
+
+router.post('/tracks/:trackId/credits/add', async ({ params: { trackId }, body: { artistId, name, role } }, res) => {
+  res.send(await addArtistCredit(trackId, { artistId, name }, role))
+})
+
+router.post('/tracks/:trackId/credits/remove', async ({ params: { trackId }, body: { artistId, role } }, res) => {
+  res.send(await removeArtistCredit(trackId, artistId, role))
 })
 
 module.exports = router

--- a/packages/back/routes/admin/artist-split-logic.js
+++ b/packages/back/routes/admin/artist-split-logic.js
@@ -1,0 +1,39 @@
+// Heuristics for spotting an artist record whose name actually bundles several
+// artists (e.g. "Sleepnet & Lumen", "Unglued x Whiney", "Camo & Krooked
+// featuring Rezar"). Detection is intentionally permissive — many real names
+// contain these tokens ("Camo & Krooked") — so a flag is only a suggestion an
+// admin reviews, splits, or ignores. Pure string functions, no DB, so they can
+// be unit tested and shared between the detection job and the admin layer.
+
+// Word separators are only treated as such when surrounded by whitespace, so
+// the "x" in "Mxrcy" or the "and" in "Anderson" never matches. Longer
+// alternatives come first so "featuring" wins over "feat", "vs." over "vs".
+const WORD_SEPARATORS = ['featuring', 'feat\\.?', 'ft\\.?', 'versus', 'vs\\.?', 'presents', 'pres\\.?', 'and', 'x']
+
+// Symbol separators may appear with or without surrounding whitespace ("A, B"
+// and "A,B" both split).
+const SYMBOL_SEPARATOR_CLASS = '[&,+/;]'
+
+const WORD_SEPARATOR_PATTERN = `\\s+(?:${WORD_SEPARATORS.join('|')})\\s+`
+const SYMBOL_SEPARATOR_PATTERN = `\\s*${SYMBOL_SEPARATOR_CLASS}\\s*`
+
+const SPLIT_REGEX = new RegExp(`${SYMBOL_SEPARATOR_PATTERN}|${WORD_SEPARATOR_PATTERN}`, 'gi')
+// A fresh non-global copy: a shared /g regex carries lastIndex between .test()
+// calls and would give alternating results.
+const DETECT_REGEX = new RegExp(`${SYMBOL_SEPARATOR_PATTERN}|${WORD_SEPARATOR_PATTERN}`, 'i')
+
+// True when the name contains at least one separator that commonly joins
+// multiple artists.
+const hasSplitSeparators = (name) => (name ? DETECT_REGEX.test(name) : false)
+
+// Best-effort split of a combined name into its parts, trimmed and de-duped of
+// empties. Only a starting point for the admin: e.g. "Camo & Krooked featuring
+// Rezar" yields ["Camo", "Krooked", "Rezar"] and the admin recombines the first
+// two if "Camo & Krooked" is one artist.
+const suggestArtistSplit = (name) =>
+  (name || '')
+    .split(SPLIT_REGEX)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+
+module.exports = { hasSplitSeparators, suggestArtistSplit }

--- a/packages/back/routes/admin/database-reset-policy.js
+++ b/packages/back/routes/admin/database-reset-policy.js
@@ -1,0 +1,14 @@
+// Whether the destructive "reset the database" admin feature may run.
+//
+// The ONLY signal that distinguishes a preview/review deployment from
+// production is PREVIEW_ENV (surfaced as config.isPreviewEnv). NODE_ENV is
+// deliberately NOT consulted: Heroku review apps run with NODE_ENV=production
+// just like the real production app, so config.isProduction is true in preview
+// too and gating on it would wrongly disable the feature in preview while
+// adding no protection. This mirrors the Actions-bot admin gate in
+// routes/shared/auth.js, whose comment notes isPreviewEnv is the
+// defence-in-depth that "can never grant admin in production". Production never
+// sets PREVIEW_ENV=true, so the reset can never be available there.
+const isDatabaseResetAllowed = ({ isPreviewEnv } = {}) => isPreviewEnv === true
+
+module.exports = { isDatabaseResetAllowed }

--- a/packages/back/routes/admin/db.js
+++ b/packages/back/routes/admin/db.js
@@ -1376,47 +1376,101 @@ INSERT INTO artist (artist_name) VALUES (${name}) RETURNING artist_id`,
   return created.artist_id
 }
 
-// Retire an artist that no longer holds any track credits, mirroring
-// cleanupMislabeledSource: keep it if it still has Bandcamp followers, otherwise
-// remove the rows that reference it (its split candidate, mislabeled flags,
-// store mappings, genres and ignores all cascade or are cleared here) and delete
-// it. Runs in its own transaction so a delete failure cannot roll back an
-// already-applied re-crediting.
-const deleteArtistIfOrphaned = async (artistId) => {
-  const [{ hasFollowers }] = await pg.queryRowsAsync(
+// Carry the source artist's followers over to the split targets, then retire
+// the source. Each user following the source becomes a follower of every target
+// that has a store presence (a store__artist row that can host a watch); new
+// artists created by name during the split have no store page to follow, so
+// they receive no watchers. The source's own credits are already gone, so
+// removing it just clears the rows that reference it (split candidate,
+// mislabeled flags, store mappings + their watches, genres and ignores all
+// cascade or are cleared here). Runs in its own transaction so a failure here
+// cannot roll back the already-applied re-crediting; if a follower could not be
+// rehomed (no store-backed target) the source is kept rather than dropping the
+// follow.
+const retireSplitSource = async (sourceId, targetIds) => {
+  const followers = await pg.queryRowsAsync(
     // language=PostgreSQL
-    sql`-- deleteArtistIfOrphaned followers?
-SELECT EXISTS (SELECT 1
-               FROM
-                 store__artist_watch saw
-                 JOIN store__artist sa ON sa.store__artist_id = saw.store__artist_id
-               WHERE sa.artist_id = ${artistId}) AS "hasFollowers"`,
+    sql`-- retireSplitSource followers
+SELECT DISTINCT sawu.meta_account_user_id AS "userId"
+FROM
+  store__artist_watch__user sawu
+  JOIN store__artist_watch saw ON saw.store__artist_watch_id = sawu.store__artist_watch_id
+  JOIN store__artist sa ON sa.store__artist_id = saw.store__artist_id
+WHERE sa.artist_id = ${sourceId}`,
   )
-  if (hasFollowers) {
-    await markArtistSplitCandidateSplit(pg, artistId)
-    return false
+  const followerUserIds = followers.map((f) => f.userId)
+
+  // One store__artist per store-backed target to host the migrated follows.
+  const targetStoreArtists =
+    targetIds.length === 0
+      ? []
+      : await pg.queryRowsAsync(
+          // language=PostgreSQL
+          sql`-- retireSplitSource target store artists
+SELECT DISTINCT ON (artist_id) artist_id AS "artistId", store__artist_id AS "storeArtistId"
+FROM store__artist
+WHERE artist_id = ANY (${targetIds})
+ORDER BY artist_id, store__artist_id`,
+        )
+
+  // Followers exist but no target can hold a watch: keep the source so the
+  // follow is not silently lost.
+  if (followerUserIds.length > 0 && targetStoreArtists.length === 0) {
+    await markArtistSplitCandidateSplit(pg, sourceId)
+    logger.warn(
+      `splitArtist: kept source artist ${sourceId} — it has ${followerUserIds.length} follower(s) but no split target has a store page to receive them`,
+    )
+    return { deleted: false, followersMigrated: 0, followerCount: followerUserIds.length }
   }
+
   try {
+    let followersMigrated = 0
     await BPromise.using(pg.getTransaction(), async (tx) => {
-      await tx.queryAsync(sql`DELETE FROM user__artist_ignore WHERE artist_id = ${artistId}`)
-      await tx.queryAsync(sql`DELETE FROM user__artist__label_ignore WHERE artist_id = ${artistId}`)
-      await tx.queryAsync(sql`DELETE FROM artist__genre WHERE artist_id = ${artistId}`)
-      await tx.queryAsync(sql`DELETE FROM store__artist WHERE artist_id = ${artistId}`)
-      await tx.queryAsync(sql`DELETE FROM artist WHERE artist_id = ${artistId}`)
+      if (followerUserIds.length > 0) {
+        for (const { storeArtistId } of targetStoreArtists) {
+          await tx.queryAsync(
+            // language=PostgreSQL
+            sql`-- retireSplitSource ensure target watch
+INSERT INTO store__artist_watch (store__artist_id) VALUES (${storeArtistId})
+ON CONFLICT (store__artist_id) DO NOTHING`,
+          )
+          const [{ watchId }] = await tx.queryRowsAsync(
+            sql`SELECT store__artist_watch_id AS "watchId" FROM store__artist_watch WHERE store__artist_id = ${storeArtistId}`,
+          )
+          const migrated = await tx.queryRowsAsync(
+            // language=PostgreSQL
+            sql`-- retireSplitSource migrate followers
+INSERT INTO store__artist_watch__user (store__artist_watch_id, meta_account_user_id)
+SELECT ${watchId}, UNNEST(${followerUserIds}::int[])
+ON CONFLICT (store__artist_watch_id, meta_account_user_id) DO NOTHING
+RETURNING meta_account_user_id AS "userId"`,
+          )
+          followersMigrated += migrated.length
+        }
+      }
+
+      await tx.queryAsync(sql`DELETE FROM user__artist_ignore WHERE artist_id = ${sourceId}`)
+      await tx.queryAsync(sql`DELETE FROM user__artist__label_ignore WHERE artist_id = ${sourceId}`)
+      await tx.queryAsync(sql`DELETE FROM artist__genre WHERE artist_id = ${sourceId}`)
+      // Drops the source's store__artist rows and, via ON DELETE CASCADE, its
+      // own watches and the watcher rows now copied onto the targets.
+      await tx.queryAsync(sql`DELETE FROM store__artist WHERE artist_id = ${sourceId}`)
+      await tx.queryAsync(sql`DELETE FROM artist WHERE artist_id = ${sourceId}`)
     })
-    return true
+    return { deleted: true, followersMigrated, followerCount: followerUserIds.length }
   } catch (e) {
-    logger.warn(`splitArtist: could not delete source artist ${artistId}: ${e.message}`)
-    await markArtistSplitCandidateSplit(pg, artistId)
-    return false
+    logger.warn(`splitArtist: could not retire source artist ${sourceId}: ${e.message}`)
+    await markArtistSplitCandidateSplit(pg, sourceId)
+    return { deleted: false, followersMigrated: 0, followerCount: followerUserIds.length }
   }
 }
 
 // Split a combined artist into the individual artists it bundles. Every track
 // credited to the source is re-credited to each target (preserving the original
 // role), the source's genres are carried over, the source's own credits are
-// dropped, affected tracks' cached details refreshed, and the now-empty source
-// retired. Targets may be existing artists or new ones created by name.
+// dropped, affected tracks' cached details refreshed, the source's followers
+// moved onto the targets, and the now-empty source retired. Targets may be
+// existing artists or new ones created by name.
 module.exports.splitArtist = async (sourceId, targets) => {
   const parsedSource = parseInt(sourceId, 10)
   if (Number.isNaN(parsedSource)) throw new Error('Invalid source artist id')
@@ -1479,7 +1533,7 @@ ON CONFLICT DO NOTHING`,
     },
   )
 
-  const deleted = await deleteArtistIfOrphaned(parsedSource)
+  const { deleted, followersMigrated, followerCount } = await retireSplitSource(parsedSource, targetArtistIds)
 
   logger.info(
     `splitArtist: artist ${parsedSource} ("${source.name}") -> [${targetArtistIds.join(', ')}]` +
@@ -1491,11 +1545,13 @@ ON CONFLICT DO NOTHING`,
       targetArtistIds,
       createdArtists,
       trackCount,
+      followerCount,
+      followersMigrated,
       deleted,
     },
   )
 
-  return { deleted, targetArtistIds, createdArtists, trackCount }
+  return { deleted, targetArtistIds, createdArtists, trackCount, followerCount, followersMigrated }
 }
 
 // Add an artist credit to a single track (used by the inspect page). The target

--- a/packages/back/routes/admin/db.js
+++ b/packages/back/routes/admin/db.js
@@ -22,6 +22,11 @@ const {
 const {
   static: { nameSubdomainSimilarity, getSubdomain, nameSubdomainSimilarityThreshold },
 } = require('../stores/bandcamp/bandcamp-api')
+const {
+  getArtistSplitCandidates,
+  ignoreArtistSplitCandidate,
+  markArtistSplitCandidateSplit,
+} = require('../shared/db/artistSplit')
 
 const BANDCAMP_STORE_URL = 'https://bandcamp.com'
 
@@ -1304,4 +1309,251 @@ module.exports.removeArtistUrl = async (id) => {
     storeArtistRowsCleared,
   })
   return { cleared: storeArtistRowsCleared.length }
+}
+
+// --- Artist splitting -------------------------------------------------------
+
+module.exports.getArtistSplitCandidates = async () => getArtistSplitCandidates()
+
+module.exports.ignoreArtistSplitCandidate = async (artistId) => {
+  const parsed = parseInt(artistId, 10)
+  if (Number.isNaN(parsed)) throw new Error('Invalid id')
+  await ignoreArtistSplitCandidate(parsed)
+}
+
+// Tracks credited to an artist, each with its full set of credits (artist id,
+// name and role) so the admin can see and edit every track's attribution. Used
+// by the split inspect page; works for any artist, flagged or not.
+module.exports.getArtistTracks = async (artistId) => {
+  const parsedId = parseInt(artistId, 10)
+  if (Number.isNaN(parsedId)) throw new Error('Invalid id')
+  return pg.queryRowsAsync(
+    // language=PostgreSQL
+    sql`-- getArtistTracks
+SELECT DISTINCT ON (t.track_id)
+       t.track_id            AS id
+     , t.track_title         AS title
+     , t.track_version       AS version
+     , ta.track__artist_role AS role
+     , r.release_name        AS "releaseName"
+     , sr.store__release_url AS "releaseUrl"
+     , st.store__track_url   AS "trackUrl"
+     , (SELECT JSON_AGG(JSON_BUILD_OBJECT('artistId', a2.artist_id, 'name', a2.artist_name,
+                                          'role', ta2.track__artist_role)
+                        ORDER BY ta2.track__artist_role, a2.artist_name)
+        FROM track__artist ta2 JOIN artist a2 ON a2.artist_id = ta2.artist_id
+        WHERE ta2.track_id = t.track_id) AS credits
+FROM
+  track__artist ta
+  JOIN track t ON t.track_id = ta.track_id
+  LEFT JOIN release__track rt ON rt.track_id = t.track_id
+  LEFT JOIN release r ON r.release_id = rt.release_id
+  LEFT JOIN store s ON s.store_url = ${BANDCAMP_STORE_URL}
+  LEFT JOIN store__release sr ON sr.release_id = r.release_id AND sr.store_id = s.store_id
+  LEFT JOIN store__track st ON st.track_id = t.track_id AND st.store_id = s.store_id
+WHERE ta.artist_id = ${parsedId}
+ORDER BY t.track_id, r.release_name`,
+  )
+}
+
+// Resolve a split/credit target to an artist id within a transaction. A target
+// is either an existing artist ({ artistId }) or a new one to create by name
+// ({ name }); artist names are not unique, so a named target always inserts.
+const resolveTargetArtistId = async (tx, target) => {
+  if (target && target.artistId != null && target.artistId !== '') {
+    const id = parseInt(target.artistId, 10)
+    if (Number.isNaN(id)) throw new Error('Invalid target artist id')
+    const [row] = await tx.queryRowsAsync(sql`SELECT artist_id FROM artist WHERE artist_id = ${id}`)
+    if (!row) throw new Error(`Target artist ${id} not found`)
+    return id
+  }
+  const name = (target && target.name ? target.name : '').trim()
+  if (!name) throw new Error('Each target needs an existing artist or a name')
+  const [created] = await tx.queryRowsAsync(
+    sql`-- resolveTargetArtistId create
+INSERT INTO artist (artist_name) VALUES (${name}) RETURNING artist_id`,
+  )
+  return created.artist_id
+}
+
+// Retire an artist that no longer holds any track credits, mirroring
+// cleanupMislabeledSource: keep it if it still has Bandcamp followers, otherwise
+// remove the rows that reference it (its split candidate, mislabeled flags,
+// store mappings, genres and ignores all cascade or are cleared here) and delete
+// it. Runs in its own transaction so a delete failure cannot roll back an
+// already-applied re-crediting.
+const deleteArtistIfOrphaned = async (artistId) => {
+  const [{ hasFollowers }] = await pg.queryRowsAsync(
+    // language=PostgreSQL
+    sql`-- deleteArtistIfOrphaned followers?
+SELECT EXISTS (SELECT 1
+               FROM
+                 store__artist_watch saw
+                 JOIN store__artist sa ON sa.store__artist_id = saw.store__artist_id
+               WHERE sa.artist_id = ${artistId}) AS "hasFollowers"`,
+  )
+  if (hasFollowers) {
+    await markArtistSplitCandidateSplit(pg, artistId)
+    return false
+  }
+  try {
+    await BPromise.using(pg.getTransaction(), async (tx) => {
+      await tx.queryAsync(sql`DELETE FROM user__artist_ignore WHERE artist_id = ${artistId}`)
+      await tx.queryAsync(sql`DELETE FROM user__artist__label_ignore WHERE artist_id = ${artistId}`)
+      await tx.queryAsync(sql`DELETE FROM artist__genre WHERE artist_id = ${artistId}`)
+      await tx.queryAsync(sql`DELETE FROM store__artist WHERE artist_id = ${artistId}`)
+      await tx.queryAsync(sql`DELETE FROM artist WHERE artist_id = ${artistId}`)
+    })
+    return true
+  } catch (e) {
+    logger.warn(`splitArtist: could not delete source artist ${artistId}: ${e.message}`)
+    await markArtistSplitCandidateSplit(pg, artistId)
+    return false
+  }
+}
+
+// Split a combined artist into the individual artists it bundles. Every track
+// credited to the source is re-credited to each target (preserving the original
+// role), the source's genres are carried over, the source's own credits are
+// dropped, affected tracks' cached details refreshed, and the now-empty source
+// retired. Targets may be existing artists or new ones created by name.
+module.exports.splitArtist = async (sourceId, targets) => {
+  const parsedSource = parseInt(sourceId, 10)
+  if (Number.isNaN(parsedSource)) throw new Error('Invalid source artist id')
+  if (!Array.isArray(targets) || targets.length < 2) {
+    throw new Error('A split needs at least two target artists')
+  }
+
+  const { source, targetArtistIds, createdArtists, trackCount } = await BPromise.using(
+    pg.getTransaction(),
+    async (tx) => {
+      const [src] = await tx.queryRowsAsync(sql`SELECT artist_name AS name FROM artist WHERE artist_id = ${parsedSource}`)
+      if (!src) throw new Error(`Artist ${parsedSource} not found`)
+
+      const resolved = []
+      const created = []
+      for (const target of targets) {
+        const isNew = !(target && target.artistId != null && target.artistId !== '')
+        const id = await resolveTargetArtistId(tx, target)
+        if (id === parsedSource) throw new Error('Cannot split an artist into itself')
+        if (isNew) created.push({ id, name: (target.name || '').trim() })
+        resolved.push(id)
+      }
+      const uniqueTargetIds = [...new Set(resolved)]
+
+      const credits = await tx.queryRowsAsync(
+        sql`-- splitArtist source credits
+SELECT track_id AS "trackId", track__artist_role AS role FROM track__artist WHERE artist_id = ${parsedSource}`,
+      )
+      const trackIds = [...new Set(credits.map((c) => c.trackId))]
+
+      for (const { trackId, role } of credits) {
+        for (const targetId of uniqueTargetIds) {
+          await tx.queryAsync(
+            // language=PostgreSQL
+            sql`-- splitArtist add credit
+INSERT INTO track__artist (track_id, artist_id, track__artist_role)
+VALUES (${trackId}, ${targetId}, ${role})
+ON CONFLICT ON CONSTRAINT track__artist_track_id_artist_id_track__artist_role_key DO NOTHING`,
+          )
+        }
+      }
+
+      for (const targetId of uniqueTargetIds) {
+        await tx.queryAsync(
+          // language=PostgreSQL
+          sql`-- splitArtist carry genres
+INSERT INTO artist__genre (artist_id, genre_id)
+SELECT ${targetId}, genre_id FROM artist__genre WHERE artist_id = ${parsedSource}
+ON CONFLICT DO NOTHING`,
+        )
+      }
+
+      await tx.queryAsync(sql`DELETE FROM track__artist WHERE artist_id = ${parsedSource}`)
+      await refreshTrackDetails(tx, trackIds)
+      // Mark resolved up front; if the source can be deleted below the row goes
+      // away via ON DELETE CASCADE, otherwise this keeps it off the list.
+      await markArtistSplitCandidateSplit(tx, parsedSource)
+
+      return { source: src, targetArtistIds: uniqueTargetIds, createdArtists: created, trackCount: trackIds.length }
+    },
+  )
+
+  const deleted = await deleteArtistIfOrphaned(parsedSource)
+
+  logger.info(
+    `splitArtist: artist ${parsedSource} ("${source.name}") -> [${targetArtistIds.join(', ')}]` +
+      (deleted ? ' (source deleted)' : ' (source kept)'),
+    {
+      operation: 'splitArtist',
+      sourceArtistId: parsedSource,
+      sourceName: source.name,
+      targetArtistIds,
+      createdArtists,
+      trackCount,
+      deleted,
+    },
+  )
+
+  return { deleted, targetArtistIds, createdArtists, trackCount }
+}
+
+// Add an artist credit to a single track (used by the inspect page). The target
+// may be an existing artist or a new one created by name; the role defaults to
+// author.
+module.exports.addArtistCredit = async (trackId, target, role) => {
+  const parsedTrack = parseInt(trackId, 10)
+  if (Number.isNaN(parsedTrack)) throw new Error('Invalid track id')
+  const creditRole = role === 'remixer' ? 'remixer' : 'author'
+
+  return BPromise.using(pg.getTransaction(), async (tx) => {
+    const [track] = await tx.queryRowsAsync(sql`SELECT track_id FROM track WHERE track_id = ${parsedTrack}`)
+    if (!track) throw new Error(`Track ${parsedTrack} not found`)
+    const artistId = await resolveTargetArtistId(tx, target)
+    await tx.queryAsync(
+      // language=PostgreSQL
+      sql`-- addArtistCredit
+INSERT INTO track__artist (track_id, artist_id, track__artist_role)
+VALUES (${parsedTrack}, ${artistId}, ${creditRole})
+ON CONFLICT ON CONSTRAINT track__artist_track_id_artist_id_track__artist_role_key DO NOTHING`,
+    )
+    await refreshTrackDetails(tx, [parsedTrack])
+    const [{ name }] = await tx.queryRowsAsync(sql`SELECT artist_name AS name FROM artist WHERE artist_id = ${artistId}`)
+    logger.info(`addArtistCredit: track ${parsedTrack} += artist ${artistId} ("${name}", ${creditRole})`, {
+      operation: 'addArtistCredit',
+      trackId: parsedTrack,
+      artistId,
+      role: creditRole,
+    })
+    return { trackId: parsedTrack, artistId, name, role: creditRole }
+  })
+}
+
+// Remove an artist credit from a single track (used by the inspect page).
+module.exports.removeArtistCredit = async (trackId, artistId, role) => {
+  const parsedTrack = parseInt(trackId, 10)
+  const parsedArtist = parseInt(artistId, 10)
+  if (Number.isNaN(parsedTrack) || Number.isNaN(parsedArtist)) throw new Error('Invalid id')
+
+  return BPromise.using(pg.getTransaction(), async (tx) => {
+    if (role) {
+      await tx.queryAsync(
+        sql`-- removeArtistCredit (role)
+DELETE FROM track__artist WHERE track_id = ${parsedTrack} AND artist_id = ${parsedArtist} AND track__artist_role = ${role}`,
+      )
+    } else {
+      await tx.queryAsync(
+        sql`-- removeArtistCredit
+DELETE FROM track__artist WHERE track_id = ${parsedTrack} AND artist_id = ${parsedArtist}`,
+      )
+    }
+    await refreshTrackDetails(tx, [parsedTrack])
+    logger.info(`removeArtistCredit: track ${parsedTrack} -= artist ${parsedArtist} (${role || 'any role'})`, {
+      operation: 'removeArtistCredit',
+      trackId: parsedTrack,
+      artistId: parsedArtist,
+      role: role || null,
+    })
+    return { trackId: parsedTrack, artistId: parsedArtist, role: role || null }
+  })
 }

--- a/packages/back/routes/admin/db.js
+++ b/packages/back/routes/admin/db.js
@@ -1035,18 +1035,26 @@ module.exports.getMislabeledEntityTracks = async (type, id) => {
 // Move one track's link from a mislabeled source entity to the correct target.
 // Source and target may be different types (e.g. a label-as-artist track moved
 // onto a label): we add the target link and drop the source link.
-module.exports.reassignTrack = async ({ sourceType, sourceId, targetType, targetId, trackId, role }) => {
+module.exports.reassignTrack = async ({ sourceType, sourceId, targetType, targetId, targetName, trackId, role }) => {
   if (!MISLABELED_ENTITY_TYPES.includes(sourceType) || !MISLABELED_ENTITY_TYPES.includes(targetType)) {
     throw new Error('Invalid entity type')
   }
   const src = parseInt(sourceId, 10)
-  const tgt = parseInt(targetId, 10)
   const track = parseInt(trackId, 10)
-  if ([src, tgt, track].some((n) => Number.isNaN(n))) throw new Error('Invalid id')
-  if (sourceType === targetType && src === tgt) throw new Error('Source and target are the same entity')
+  if ([src, track].some((n) => Number.isNaN(n))) throw new Error('Invalid id')
+  const hasTargetId = targetId != null && targetId !== ''
+  if (targetType === 'label' && !hasTargetId) throw new Error('Pick an existing label to reassign to')
 
   const targetRole = targetType === 'artist' ? role || 'author' : null
+  let tgt
   await BPromise.using(pg.getTransaction(), async (tx) => {
+    tgt =
+      targetType === 'artist'
+        ? await resolveTargetArtistId(tx, hasTargetId ? { artistId: targetId } : { name: targetName })
+        : parseInt(targetId, 10)
+    if (Number.isNaN(tgt)) throw new Error('Invalid id')
+    if (sourceType === targetType && src === tgt) throw new Error('Source and target are the same entity')
+
     if (targetType === 'artist') {
       await tx.queryAsync(sql`-- reassignTrack add artist
         INSERT INTO track__artist (track_id, artist_id, track__artist_role)
@@ -1091,19 +1099,27 @@ module.exports.reassignTrack = async ({ sourceType, sourceId, targetType, target
 // source entity onto the correct target, in a single transaction. Used from the
 // inspect view to re-attribute a whole release at once (e.g. a compilation whose
 // tracks were all collapsed onto the label name). Each track keeps its own role.
-module.exports.reassignReleaseTracks = async ({ sourceType, sourceId, targetType, targetId, releaseId }) => {
+module.exports.reassignReleaseTracks = async ({ sourceType, sourceId, targetType, targetId, targetName, releaseId }) => {
   if (!MISLABELED_ENTITY_TYPES.includes(sourceType) || !MISLABELED_ENTITY_TYPES.includes(targetType)) {
     throw new Error('Invalid entity type')
   }
   const src = parseInt(sourceId, 10)
-  const tgt = parseInt(targetId, 10)
   const rel = parseInt(releaseId, 10)
-  if ([src, tgt, rel].some((n) => Number.isNaN(n))) throw new Error('Invalid id')
-  if (sourceType === targetType && src === tgt) throw new Error('Source and target are the same entity')
+  if ([src, rel].some((n) => Number.isNaN(n))) throw new Error('Invalid id')
+  const hasTargetId = targetId != null && targetId !== ''
+  if (targetType === 'label' && !hasTargetId) throw new Error('Pick an existing label to reassign to')
 
   let reassigned = 0
+  let tgt
   const reassignedTrackIds = []
   await BPromise.using(pg.getTransaction(), async (tx) => {
+    tgt =
+      targetType === 'artist'
+        ? await resolveTargetArtistId(tx, hasTargetId ? { artistId: targetId } : { name: targetName })
+        : parseInt(targetId, 10)
+    if (Number.isNaN(tgt)) throw new Error('Invalid id')
+    if (sourceType === targetType && src === tgt) throw new Error('Source and target are the same entity')
+
     const tracks =
       sourceType === 'artist'
         ? await tx.queryRowsAsync(sql`-- reassignReleaseTracks find artist tracks

--- a/packages/back/routes/admin/reset-database.js
+++ b/packages/back/routes/admin/reset-database.js
@@ -1,14 +1,29 @@
 const pg = require('fomoplayer_shared').db.pg
 const logger = require('fomoplayer_shared').logger(__filename)
 const config = require('../../config')
-const dbConfig = require('../../database.json')
 const { isDatabaseResetAllowed } = require('./database-reset-policy')
 
-// Heroku deploys (production AND preview) run migrations through the `prod`
-// db-migrate environment (see the Procfile's db-migrate:prod and database.json),
-// which resolves its connection from DATABASE_URL. Reuse it so a programmatic
-// reset rebuilds the schema exactly the way a deploy does.
-const DB_MIGRATE_ENV = 'prod'
+// db-migrate env label. Deploys run migrations under `prod` (or `ci` in CI);
+// the reset only runs in preview, which is NODE_ENV=production -> `prod`.
+const DB_MIGRATE_ENV = process.env.NODE_ENV === 'ci' ? 'ci' : 'prod'
+
+// Connection for the migration run, built to match the app's own pg pool
+// (packages/shared/db/pg.js) exactly. We deliberately do NOT use database.json's
+// `prod` entry: that connects via DATABASE_URL with no SSL options, but the app
+// — and the schema drop below — connect via DATABASE_URL_PRIVATE with the
+// DATABASE_USE_SSL / DATABASE_SELF_SIGNED_CERT settings. Where those differ
+// (e.g. Railway private networking, where DATABASE_URL is a public proxy that
+// requires SSL), db-migrate would otherwise fail to connect and up() would
+// stall after the schema had already been dropped. db-migrate-pg passes this
+// whole object to `new pg.Client(...)`, which honours connectionString + ssl
+// together.
+const migrationDbConfig = () => ({
+  driver: 'pg',
+  connectionString: process.env.DATABASE_URL_PRIVATE || process.env.DATABASE_URL,
+  ssl: Boolean(process.env.DATABASE_USE_SSL)
+    ? { rejectUnauthorized: !Boolean(process.env.DATABASE_SELF_SIGNED_CERT) }
+    : false,
+})
 
 // A human-recognisable name for the environment being reset, used as the
 // type-to-confirm token in the UI and re-validated server-side. Derived from
@@ -35,24 +50,34 @@ const assertResetAllowed = () => {
 // again here as the last line of defence even though the route also checks.
 const resetDatabase = async () => {
   assertResetAllowed()
-  logger.warn('Admin-triggered database reset: dropping public schema', {
-    operation: 'resetDatabase',
-    environment: databaseResetEnvironmentName(),
-  })
+  const environment = databaseResetEnvironmentName()
+  logger.warn('Admin-triggered database reset: dropping public schema', { operation: 'resetDatabase', environment })
   await pg.queryAsync('DROP SCHEMA IF EXISTS public CASCADE')
   await pg.queryAsync('CREATE SCHEMA public')
   await pg.queryAsync('GRANT ALL ON SCHEMA public TO CURRENT_USER')
 
+  logger.warn('Admin-triggered database reset: running migrations', { operation: 'resetDatabase', environment })
   const dbMigrate = require('db-migrate').getInstance(true, {
-    config: dbConfig,
+    config: { [DB_MIGRATE_ENV]: migrationDbConfig() },
     cwd: `${__dirname}/../../`,
     env: DB_MIGRATE_ENV,
   })
-  dbMigrate.silence(true)
-  await dbMigrate.up()
+  // Leave db-migrate's own logging on so migration progress reaches the
+  // platform logs — this step had previously stalled invisibly.
+  dbMigrate.silence(false)
+  try {
+    await dbMigrate.up()
+  } catch (e) {
+    logger.error('Admin-triggered database reset: migrations failed', {
+      operation: 'resetDatabase',
+      environment,
+      error: e.message,
+    })
+    throw e
+  }
   logger.warn('Admin-triggered database reset complete: schema rebuilt and migrations applied', {
     operation: 'resetDatabase',
-    environment: databaseResetEnvironmentName(),
+    environment,
   })
 }
 

--- a/packages/back/routes/admin/reset-database.js
+++ b/packages/back/routes/admin/reset-database.js
@@ -1,0 +1,59 @@
+const pg = require('fomoplayer_shared').db.pg
+const logger = require('fomoplayer_shared').logger(__filename)
+const config = require('../../config')
+const dbConfig = require('../../database.json')
+const { isDatabaseResetAllowed } = require('./database-reset-policy')
+
+// Heroku deploys (production AND preview) run migrations through the `prod`
+// db-migrate environment (see the Procfile's db-migrate:prod and database.json),
+// which resolves its connection from DATABASE_URL. Reuse it so a programmatic
+// reset rebuilds the schema exactly the way a deploy does.
+const DB_MIGRATE_ENV = 'prod'
+
+// A human-recognisable name for the environment being reset, used as the
+// type-to-confirm token in the UI and re-validated server-side. Derived from
+// runtime config/env (never a hard-coded deployment host), so it identifies the
+// specific preview the operator is on.
+const databaseResetEnvironmentName = () => {
+  if (process.env.HEROKU_APP_NAME) return process.env.HEROKU_APP_NAME
+  try {
+    return new URL(config.apiURL).hostname
+  } catch {
+    return 'preview'
+  }
+}
+
+const assertResetAllowed = () => {
+  if (!isDatabaseResetAllowed(config)) {
+    throw new Error('Database reset is only available in preview environments')
+  }
+}
+
+// Drop and recreate the public schema, then re-run every migration. This yields
+// a clean, current schema with no data — the same build a fresh deploy
+// produces — rather than relying on down-migrations. Preview only; guarded
+// again here as the last line of defence even though the route also checks.
+const resetDatabase = async () => {
+  assertResetAllowed()
+  logger.warn('Admin-triggered database reset: dropping public schema', {
+    operation: 'resetDatabase',
+    environment: databaseResetEnvironmentName(),
+  })
+  await pg.queryAsync('DROP SCHEMA IF EXISTS public CASCADE')
+  await pg.queryAsync('CREATE SCHEMA public')
+  await pg.queryAsync('GRANT ALL ON SCHEMA public TO CURRENT_USER')
+
+  const dbMigrate = require('db-migrate').getInstance(true, {
+    config: dbConfig,
+    cwd: `${__dirname}/../../`,
+    env: DB_MIGRATE_ENV,
+  })
+  dbMigrate.silence(true)
+  await dbMigrate.up()
+  logger.warn('Admin-triggered database reset complete: schema rebuilt and migrations applied', {
+    operation: 'resetDatabase',
+    environment: databaseResetEnvironmentName(),
+  })
+}
+
+module.exports = { resetDatabase, assertResetAllowed, databaseResetEnvironmentName }

--- a/packages/back/routes/shared/db/artistSplit.js
+++ b/packages/back/routes/shared/db/artistSplit.js
@@ -1,0 +1,77 @@
+const sql = require('sql-template-strings')
+const pg = require('fomoplayer_shared').db.pg
+
+// Cache of artists whose name looks like it bundles several artists, populated
+// by detectArtistSplitCandidates and read by the admin UI. Detection only;
+// splitting is admin-driven so legitimate compound names (e.g. "Camo &
+// Krooked") are never split blindly.
+
+// Artists to (re-)scan: everything except those already dismissed or split, so
+// a re-run does not resurrect a decision an admin already made.
+module.exports.getArtistsForSplitScan = async () =>
+  pg.queryRowsAsync(
+    // language=PostgreSQL
+    sql`-- getArtistsForSplitScan
+SELECT a.artist_id   AS "artistId"
+     , a.artist_name AS name
+FROM artist a
+WHERE NOT EXISTS (SELECT 1
+                  FROM artist_split_candidate c
+                  WHERE c.artist_id = a.artist_id
+                    AND c.artist_split_candidate_status IN ('ignored', 'split'))`,
+  )
+
+module.exports.flagArtistSplitCandidate = async ({ artistId, name, suggestions }) =>
+  pg.queryAsync(
+    // language=PostgreSQL
+    sql`-- flagArtistSplitCandidate
+INSERT INTO artist_split_candidate
+  (artist_id, artist_split_candidate_name, artist_split_candidate_suggestions, artist_split_candidate_checked_at)
+VALUES (${artistId}, ${name}, ${JSON.stringify(suggestions)}::jsonb, NOW())
+ON CONFLICT (artist_id) DO UPDATE
+  SET artist_split_candidate_name        = EXCLUDED.artist_split_candidate_name
+    , artist_split_candidate_suggestions = EXCLUDED.artist_split_candidate_suggestions
+    , artist_split_candidate_checked_at  = NOW()
+  WHERE artist_split_candidate.artist_split_candidate_status = 'new'`,
+  )
+
+// status='new' candidates joined to their (current) artist name, with a live
+// track count so the admin sees how much a split would touch.
+module.exports.getArtistSplitCandidates = async () => {
+  const rows = await pg.queryRowsAsync(
+    // language=PostgreSQL
+    sql`-- getArtistSplitCandidates
+SELECT c.artist_id                          AS id
+     , a.artist_name                        AS name
+     , c.artist_split_candidate_name        AS "detectedName"
+     , c.artist_split_candidate_suggestions AS suggestions
+     , (SELECT COUNT(DISTINCT track_id) FROM track__artist ta WHERE ta.artist_id = c.artist_id) AS "trackCount"
+FROM
+  artist_split_candidate c
+  JOIN artist a ON a.artist_id = c.artist_id
+WHERE c.artist_split_candidate_status = 'new'
+ORDER BY a.artist_name ASC`,
+  )
+  return rows.map((row) => ({ ...row, trackCount: Number(row.trackCount) }))
+}
+
+module.exports.ignoreArtistSplitCandidate = async (artistId) =>
+  pg.queryAsync(
+    // language=PostgreSQL
+    sql`-- ignoreArtistSplitCandidate
+UPDATE artist_split_candidate
+SET artist_split_candidate_status = 'ignored'
+WHERE artist_id = ${artistId}`,
+  )
+
+// Mark a candidate resolved when its source artist is kept (could not be
+// retired). When the source is deleted the row is removed via ON DELETE CASCADE
+// instead.
+module.exports.markArtistSplitCandidateSplit = async (queryable, artistId) =>
+  queryable.queryAsync(
+    // language=PostgreSQL
+    sql`-- markArtistSplitCandidateSplit
+UPDATE artist_split_candidate
+SET artist_split_candidate_status = 'split'
+WHERE artist_id = ${artistId}`,
+  )

--- a/packages/back/routes/stores/bandcamp/logic.js
+++ b/packages/back/routes/stores/bandcamp/logic.js
@@ -129,7 +129,16 @@ const releaseTracksWithFiles = (releaseDetails) => {
   return tracks.filter(R.complement(R.propEq(null, 'file')))
 }
 
-const getTracksFromReleases = async (releaseUrls) => {
+// `pageContext` carries the entity type/name detected on the followed page's
+// own /music listing (a label or artist landing page). That detection is
+// reliable; per-release detection on an individual album page is not, because a
+// single album page rarely exposes the label signals (the /artists roster link,
+// is_label, or 2+ distinct artist tiles). When a context is supplied we override
+// each release's own pageType/pageName with it so every release on a label is
+// treated as a label release — otherwise label releases collapse onto a single
+// subdomain artist. The tag/discover path passes no context (its releases have
+// no single owning page) and keeps per-release detection.
+const getTracksFromReleases = async (releaseUrls, pageContext = null) => {
   const errors = []
 
   let releaseDetails = []
@@ -137,6 +146,10 @@ const getTracksFromReleases = async (releaseUrls) => {
     logger.debug(`Processing release: ${releaseUrl}`)
     try {
       const releaseInfo = await getReleaseAsync(releaseUrl)
+      if (pageContext) {
+        releaseInfo.pageType = pageContext.pageType
+        releaseInfo.pageName = pageContext.pageName
+      }
       releaseDetails.push(releaseInfo)
     } catch (e) {
       if (e.isRateLimit) {
@@ -185,12 +198,16 @@ const filterToUnknownUrls = async (urls) => {
 
 module.exports.getArtistTracks = async function* ({ url }) {
   try {
-    const { type, releaseUrls } = await getArtistAsync(url)
+    const { type, name, releaseUrls } = await getArtistAsync(url)
     await updateMislabeledFlag('artist', url, type)
     const { unknownUrls, skipped } = await filterToUnknownUrls(releaseUrls)
     logger.debug(
       `Artist ${url}: ${releaseUrls.length} releases listed, ${skipped} already known (skipped), ${unknownUrls.length} to fetch`,
     )
+    // Detect the page's true type once, here on its /music listing, and apply it
+    // to every release: a page that is really a label must not credit all its
+    // releases to the subdomain.
+    const pageContext = { pageType: type, pageName: name }
     yield { tracks: [], errors: [], skipped, totalReleases: releaseUrls.length }
     for (const releaseUrl of unknownUrls) {
       if (isRateLimited()) {
@@ -198,7 +215,7 @@ module.exports.getArtistTracks = async function* ({ url }) {
         return
       }
       try {
-        yield await getTracksFromReleases([releaseUrl])
+        yield await getTracksFromReleases([releaseUrl], pageContext)
       } catch (e) {
         if (e.isRateLimit) {
           logger.error('Rate limit reached while getting artist tracks from release', e)
@@ -219,12 +236,16 @@ module.exports.getArtistTracks = async function* ({ url }) {
 
 module.exports.getLabelTracks = async function* ({ url }) {
   try {
-    const { type, releaseUrls } = await getLabelAsync(url)
+    const { type, name, releaseUrls } = await getLabelAsync(url)
     await updateMislabeledFlag('label', url, type)
     const { unknownUrls, skipped } = await filterToUnknownUrls(releaseUrls)
     logger.debug(
       `Label ${url}: ${releaseUrls.length} releases listed, ${skipped} already known (skipped), ${unknownUrls.length} to fetch`,
     )
+    // Detect the page's true type once, here on its /music listing, and apply it
+    // to every release so a label's releases are attributed to their real
+    // artists by name instead of all collapsing onto the label subdomain.
+    const pageContext = { pageType: type, pageName: name }
     yield { tracks: [], errors: [], skipped, totalReleases: releaseUrls.length }
     for (const releaseUrl of unknownUrls) {
       if (isRateLimited()) {
@@ -232,7 +253,7 @@ module.exports.getLabelTracks = async function* ({ url }) {
         return
       }
       try {
-        yield await getTracksFromReleases([releaseUrl])
+        yield await getTracksFromReleases([releaseUrl], pageContext)
       } catch (e) {
         if (e.isRateLimit) {
           logger.error('Rate limit reached while getting label tracks from release', e)

--- a/packages/back/test/fixtures/bandcamp-different-eyes-tracks.json
+++ b/packages/back/test/fixtures/bandcamp-different-eyes-tracks.json
@@ -6,9 +6,9 @@
     "artists": [
       {
         "name": "Billain",
-        "id": "billainaethek",
         "role": "author",
-        "url": "https://billainaethek.bandcamp.com"
+        "id": null,
+        "url": null
       }
     ],
     "released": "17 Nov 2023 00:00:00 GMT",
@@ -20,7 +20,11 @@
       "title": "Different Eyes EP",
       "id": "1051734106"
     },
-    "label": null,
+    "label": {
+      "id": "3470339956",
+      "url": "https://billainaethek.bandcamp.com",
+      "name": "VISION"
+    },
     "previews": [
       {
         "format": "mp3",
@@ -75,9 +79,9 @@
     "artists": [
       {
         "name": "Billain",
-        "id": "billainaethek",
         "role": "author",
-        "url": "https://billainaethek.bandcamp.com"
+        "id": null,
+        "url": null
       }
     ],
     "released": "17 Nov 2023 00:00:00 GMT",
@@ -89,7 +93,11 @@
       "title": "Different Eyes EP",
       "id": "1051734106"
     },
-    "label": null,
+    "label": {
+      "id": "3470339956",
+      "url": "https://billainaethek.bandcamp.com",
+      "name": "VISION"
+    },
     "previews": [
       {
         "format": "mp3",
@@ -144,9 +152,9 @@
     "artists": [
       {
         "name": "Billain",
-        "id": "billainaethek",
         "role": "author",
-        "url": "https://billainaethek.bandcamp.com"
+        "id": null,
+        "url": null
       }
     ],
     "released": "17 Nov 2023 00:00:00 GMT",
@@ -158,7 +166,11 @@
       "title": "Different Eyes EP",
       "id": "1051734106"
     },
-    "label": null,
+    "label": {
+      "id": "3470339956",
+      "url": "https://billainaethek.bandcamp.com",
+      "name": "VISION"
+    },
     "previews": [
       {
         "format": "mp3",
@@ -213,9 +225,9 @@
     "artists": [
       {
         "name": "Billain",
-        "id": "billainaethek",
         "role": "author",
-        "url": "https://billainaethek.bandcamp.com"
+        "id": null,
+        "url": null
       }
     ],
     "released": "17 Nov 2023 00:00:00 GMT",
@@ -227,7 +239,11 @@
       "title": "Different Eyes EP",
       "id": "1051734106"
     },
-    "label": null,
+    "label": {
+      "id": "3470339956",
+      "url": "https://billainaethek.bandcamp.com",
+      "name": "VISION"
+    },
     "previews": [
       {
         "format": "mp3",
@@ -282,9 +298,9 @@
     "artists": [
       {
         "name": "Billain",
-        "id": "billainaethek",
         "role": "author",
-        "url": "https://billainaethek.bandcamp.com"
+        "id": null,
+        "url": null
       }
     ],
     "released": "17 Nov 2023 00:00:00 GMT",
@@ -296,7 +312,11 @@
       "title": "Different Eyes EP",
       "id": "1051734106"
     },
-    "label": null,
+    "label": {
+      "id": "3470339956",
+      "url": "https://billainaethek.bandcamp.com",
+      "name": "VISION"
+    },
     "previews": [
       {
         "format": "mp3",
@@ -351,9 +371,9 @@
     "artists": [
       {
         "name": "Billain",
-        "id": "billainaethek",
         "role": "author",
-        "url": "https://billainaethek.bandcamp.com"
+        "id": null,
+        "url": null
       }
     ],
     "released": "17 Nov 2023 00:00:00 GMT",
@@ -365,7 +385,11 @@
       "title": "Different Eyes EP",
       "id": "1051734106"
     },
-    "label": null,
+    "label": {
+      "id": "3470339956",
+      "url": "https://billainaethek.bandcamp.com",
+      "name": "VISION"
+    },
     "previews": [
       {
         "format": "mp3",
@@ -420,9 +444,9 @@
     "artists": [
       {
         "name": "Billain",
-        "id": "billainaethek",
         "role": "author",
-        "url": "https://billainaethek.bandcamp.com"
+        "id": null,
+        "url": null
       }
     ],
     "released": "17 Nov 2023 00:00:00 GMT",
@@ -434,7 +458,11 @@
       "title": "Different Eyes EP",
       "id": "1051734106"
     },
-    "label": null,
+    "label": {
+      "id": "3470339956",
+      "url": "https://billainaethek.bandcamp.com",
+      "name": "VISION"
+    },
     "previews": [
       {
         "format": "mp3",

--- a/packages/back/test/fixtures/bandcamp-f4k-y00-tracks.json
+++ b/packages/back/test/fixtures/bandcamp-f4k-y00-tracks.json
@@ -6,9 +6,9 @@
     "artists": [
       {
         "name": "Billain",
-        "id": "billainaethek",
         "role": "author",
-        "url": "https://billainaethek.bandcamp.com"
+        "id": null,
+        "url": null
       }
     ],
     "released": "31 Dec 2023 00:00:00 GMT",
@@ -20,7 +20,11 @@
       "title": "F4K Y00",
       "id": "3959806045"
     },
-    "label": null,
+    "label": {
+      "id": "3470339956",
+      "url": "https://billainaethek.bandcamp.com",
+      "name": "VISION"
+    },
     "previews": [
       {
         "format": "mp3",
@@ -75,9 +79,9 @@
     "artists": [
       {
         "name": "Billain",
-        "id": "billainaethek",
         "role": "author",
-        "url": "https://billainaethek.bandcamp.com"
+        "id": null,
+        "url": null
       }
     ],
     "released": "31 Dec 2023 00:00:00 GMT",
@@ -89,7 +93,11 @@
       "title": "F4K Y00",
       "id": "3959806045"
     },
-    "label": null,
+    "label": {
+      "id": "3470339956",
+      "url": "https://billainaethek.bandcamp.com",
+      "name": "VISION"
+    },
     "previews": [
       {
         "format": "mp3",

--- a/packages/back/test/tests/admin/artist_split_logic.test.js
+++ b/packages/back/test/tests/admin/artist_split_logic.test.js
@@ -1,0 +1,38 @@
+const assert = require('assert')
+const { test } = require('cascade-test')
+const { hasSplitSeparators, suggestArtistSplit } = require('../../../routes/admin/artist-split-logic')
+
+test({
+  'hasSplitSeparators': {
+    'detects ampersand': () => assert.strictEqual(hasSplitSeparators('Sleepnet & Lumen'), true),
+    'detects comma with spaces': () => assert.strictEqual(hasSplitSeparators('Tiesto, Hardwell'), true),
+    'detects comma without spaces': () => assert.strictEqual(hasSplitSeparators('A,B'), true),
+    'detects " x " separator': () => assert.strictEqual(hasSplitSeparators('Unglued x Whiney'), true),
+    'detects featuring': () => assert.strictEqual(hasSplitSeparators('Camo & Krooked featuring Rezar'), true),
+    'detects feat.': () => assert.strictEqual(hasSplitSeparators('Artist feat. Guest'), true),
+    'detects vs.': () => assert.strictEqual(hasSplitSeparators('Foo vs. Bar'), true),
+    'detects slash': () => assert.strictEqual(hasSplitSeparators('Foo / Bar'), true),
+    'ignores plain single name': () => assert.strictEqual(hasSplitSeparators('Aphex Twin'), false),
+    'does not match x inside a word': () => assert.strictEqual(hasSplitSeparators('Mxrcy'), false),
+    'does not match and inside a word': () => assert.strictEqual(hasSplitSeparators('Anderson'), false),
+    'handles empty / null': () => {
+      assert.strictEqual(hasSplitSeparators(''), false)
+      assert.strictEqual(hasSplitSeparators(null), false)
+    },
+  },
+  'suggestArtistSplit': {
+    'splits on ampersand': () =>
+      assert.deepStrictEqual(suggestArtistSplit('Sleepnet & Lumen'), ['Sleepnet', 'Lumen']),
+    'splits on " x "': () => assert.deepStrictEqual(suggestArtistSplit('Unglued x Whiney'), ['Unglued', 'Whiney']),
+    'splits a compound + featuring into three parts': () =>
+      assert.deepStrictEqual(suggestArtistSplit('Camo & Krooked featuring Rezar (Red Bull Symphonic)'), [
+        'Camo',
+        'Krooked',
+        'Rezar (Red Bull Symphonic)',
+      ]),
+    'splits on comma': () => assert.deepStrictEqual(suggestArtistSplit('A, B, C'), ['A', 'B', 'C']),
+    'returns single part for a plain name': () =>
+      assert.deepStrictEqual(suggestArtistSplit('Aphex Twin'), ['Aphex Twin']),
+    'trims and drops empties': () => assert.deepStrictEqual(suggestArtistSplit('Foo &  & Bar'), ['Foo', 'Bar']),
+  },
+})

--- a/packages/back/test/tests/admin/database_reset_policy.test.js
+++ b/packages/back/test/tests/admin/database_reset_policy.test.js
@@ -1,0 +1,24 @@
+const assert = require('assert')
+const { test } = require('cascade-test')
+const { isDatabaseResetAllowed } = require('../../../routes/admin/database-reset-policy')
+
+test({
+  'isDatabaseResetAllowed': {
+    'allows reset in a preview environment': () =>
+      assert.strictEqual(isDatabaseResetAllowed({ isPreviewEnv: true }), true),
+    // Preview runs with NODE_ENV=production (isProduction true) — the feature
+    // must still be available there, gated only on isPreviewEnv.
+    'allows reset in preview even when isProduction is true': () =>
+      assert.strictEqual(isDatabaseResetAllowed({ isPreviewEnv: true, isProduction: true }), true),
+    'denies reset when not a preview environment': () =>
+      assert.strictEqual(isDatabaseResetAllowed({ isPreviewEnv: false, isProduction: true }), false),
+    'denies reset when isPreviewEnv is unset': () => {
+      assert.strictEqual(isDatabaseResetAllowed({}), false)
+      assert.strictEqual(isDatabaseResetAllowed(), false)
+    },
+    'requires the strict boolean true (no truthy coercion)': () => {
+      assert.strictEqual(isDatabaseResetAllowed({ isPreviewEnv: 'true' }), false)
+      assert.strictEqual(isDatabaseResetAllowed({ isPreviewEnv: 1 }), false)
+    },
+  },
+})

--- a/packages/front/src/Admin.css
+++ b/packages/front/src/Admin.css
@@ -98,3 +98,32 @@
     width: 100%;
   }
 }
+
+.admin-danger-zone {
+  margin-top: 2rem;
+  padding: 1rem 1.25rem;
+  border: 2px solid #b00020;
+  border-radius: 6px;
+  background: rgba(176, 0, 32, 0.08);
+}
+
+.admin-danger-zone h2 {
+  margin-top: 0;
+  color: #ff6b6b;
+}
+
+.admin-danger-zone-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.admin-danger-zone-controls input {
+  min-width: 16rem;
+}
+
+.admin-db-reset-button:enabled {
+  background: #b00020;
+  color: white;
+}

--- a/packages/front/src/Admin.js
+++ b/packages/front/src/Admin.js
@@ -187,6 +187,12 @@ class Admin extends Component {
             >
               Fix Mislabeled
             </button>
+            <button
+              className="button button-push_button button-push_button-primary"
+              onClick={() => this.props.history.push('/admin/artist-split')}
+            >
+              Split Artists
+            </button>
           </div>
         </div>
         <div className="admin-grid">

--- a/packages/front/src/Admin.js
+++ b/packages/front/src/Admin.js
@@ -5,6 +5,7 @@ import { requestJSONwithCredentials, requestWithCredentials } from './request-js
 import { apiURL } from './config'
 import beautify from 'js-beautify'
 import { withRouter } from 'react-router-dom'
+import AdminDatabaseReset from './AdminDatabaseReset'
 import './Admin.css'
 
 const L = require('partial.lenses')
@@ -310,6 +311,7 @@ class Admin extends Component {
             </form>
           </div>
         </div>
+        <AdminDatabaseReset />
       </div>
     )
   }

--- a/packages/front/src/AdminArtistSplit.css
+++ b/packages/front/src/AdminArtistSplit.css
@@ -1,0 +1,271 @@
+.admin-artist-split {
+  padding: 1rem;
+  color: white;
+  box-sizing: border-box;
+  width: 100%;
+}
+
+.admin-artist-split-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.admin-artist-split-header h1 {
+  margin: 0;
+}
+
+.admin-artist-split .muted {
+  color: #aaa;
+}
+
+.admin-artist-split button {
+  padding: 6px 12px;
+  background: #444;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.admin-artist-split button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.admin-artist-split .split-primary {
+  background: var(--fp-brand-primary, #007bff);
+}
+
+.split-manual {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #444;
+}
+
+.split-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  padding: 15px;
+  background: #222;
+  margin-bottom: 10px;
+  border-radius: 4px;
+}
+
+.split-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+}
+
+.split-suggestions {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.split-chip {
+  display: inline-block;
+  padding: 2px 8px;
+  background: #335;
+  border-radius: 10px;
+  font-size: 0.85em;
+}
+
+.split-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.split-detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.split-detail-header h2 {
+  margin: 0;
+}
+
+.split-panel {
+  background: #222;
+  border-radius: 4px;
+  padding: 12px 15px;
+  margin-bottom: 20px;
+}
+
+.split-panel h3 {
+  margin: 0 0 4px 0;
+}
+
+.split-target-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.split-target-remove {
+  flex: 0 0 auto;
+}
+
+.split-panel-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+
+.artist-field {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.artist-field-badge {
+  flex: 0 0 auto;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.75em;
+  min-width: 34px;
+  text-align: center;
+}
+
+.artist-field-badge.new {
+  background: #553;
+}
+
+.artist-field-badge.existing {
+  background: #355;
+}
+
+.artist-field-search {
+  position: relative;
+}
+
+.artist-field-search input {
+  background: #333;
+  color: white;
+  border: 1px solid #555;
+  border-radius: 4px;
+  padding: 6px;
+  min-width: 180px;
+}
+
+.artist-field-results {
+  position: absolute;
+  z-index: 10;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin: 2px 0 0 0;
+  padding: 0;
+  list-style: none;
+  background: #2a2a2a;
+  border: 1px solid #555;
+  border-radius: 4px;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.artist-field-results li button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border-radius: 0;
+}
+
+.artist-field-results li button:hover {
+  background: #444;
+}
+
+.split-tracks {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.split-tracks th,
+.split-tracks td {
+  text-align: left;
+  padding: 8px;
+  border-bottom: 1px solid #333;
+  vertical-align: top;
+}
+
+.split-credits {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.split-credit {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  background: #333;
+  border-radius: 10px;
+  font-size: 0.85em;
+}
+
+.split-credit-remove {
+  padding: 0 5px;
+  background: #633;
+  border-radius: 8px;
+  line-height: 1.4;
+  font-size: 0.85em;
+}
+
+.split-add-credit {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.split-add-credit select {
+  background: #333;
+  color: white;
+  border: 1px solid #555;
+  border-radius: 4px;
+  padding: 6px;
+}
+
+@media (max-width: 768px) {
+  .split-tracks,
+  .split-tracks thead,
+  .split-tracks tbody,
+  .split-tracks th,
+  .split-tracks td,
+  .split-tracks tr {
+    display: block;
+  }
+
+  .split-tracks thead {
+    display: none;
+  }
+
+  .split-tracks tr {
+    margin-bottom: 12px;
+    border: 1px solid #333;
+    border-radius: 4px;
+    padding: 8px;
+  }
+}

--- a/packages/front/src/AdminArtistSplit.js
+++ b/packages/front/src/AdminArtistSplit.js
@@ -189,8 +189,12 @@ function AdminArtistSplit() {
         body: { targets: validTargets.map((t) => (t.artistId ? { artistId: t.artistId } : { name: t.name })) },
       })
       window.alert(
-        `Re-credited ${res.trackCount} track${res.trackCount === 1 ? '' : 's'} to ${res.targetArtistIds.length} artists.` +
-          (res.deleted ? ' The combined artist was retired.' : ' The combined artist was kept (it still has followers).'),
+        `Re-credited ${res.trackCount} track${res.trackCount === 1 ? '' : 's'} to ${res.targetArtistIds.length} artists` +
+          (res.followerCount ? `, moved ${res.followerCount} follower${res.followerCount === 1 ? '' : 's'} to the new artists` : '') +
+          '.' +
+          (res.deleted
+            ? ' The combined artist was retired.'
+            : ' The combined artist was kept (its followers could not be moved to any target with a store page).'),
       )
       setCandidates((prev) => prev.filter((c) => c.id !== selected.id))
       setSelected(null)
@@ -304,8 +308,8 @@ function AdminArtistSplit() {
       <div className="split-panel">
         <h3>Split into separate artists</h3>
         <p className="muted">
-          Each track credited to this artist will be re-credited to all of the artists below; the combined artist is
-          then retired. Pick existing artists or type a name to create a new one.
+          Each track credited to this artist will be re-credited to all of the artists below, its followers moved to
+          them, and the combined artist then retired. Pick existing artists or type a name to create a new one.
         </p>
         {targets.map((target, index) => (
           <div key={index} className="split-target-row">

--- a/packages/front/src/AdminArtistSplit.js
+++ b/packages/front/src/AdminArtistSplit.js
@@ -1,0 +1,430 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { useHistory } from 'react-router-dom'
+import { requestJSONwithCredentials } from './request-json-with-credentials'
+import { apiURL } from './config'
+import './AdminArtistSplit.css'
+
+const BandcampLink = ({ url, children }) =>
+  url ? (
+    <a href={url} target="_blank" rel="noopener noreferrer">
+      {children}
+    </a>
+  ) : (
+    <>{children}</>
+  )
+
+const formatCredit = (credit) => `${credit.name} (${credit.role})`
+
+// A single artist input: type a name to create a new artist, or pick an
+// existing one from the autocomplete. `value` is { name } for a new artist or
+// { artistId, name } for an existing one; the badge shows which.
+function ArtistField({ value, onChange, processing, placeholder }) {
+  const [results, setResults] = useState([])
+  const [open, setOpen] = useState(false)
+  const name = (value && value.name) || ''
+
+  useEffect(() => {
+    const q = name.trim()
+    if (!q) {
+      setResults([])
+      return undefined
+    }
+    let active = true
+    const timer = setTimeout(async () => {
+      try {
+        const rows = await requestJSONwithCredentials({
+          url: `${apiURL}/entities/search?type=artist&q=${encodeURIComponent(q)}`,
+        })
+        if (active) setResults(rows)
+      } catch (e) {
+        console.error(e)
+      }
+    }, 200)
+    return () => {
+      active = false
+      clearTimeout(timer)
+    }
+  }, [name])
+
+  return (
+    <div className="artist-field">
+      <span className={`artist-field-badge ${value && value.artistId ? 'existing' : 'new'}`}>
+        {value && value.artistId ? `#${value.artistId}` : 'new'}
+      </span>
+      <div className="artist-field-search">
+        <input
+          type="text"
+          placeholder={placeholder || 'Artist name…'}
+          value={name}
+          disabled={processing}
+          onChange={(e) => {
+            onChange({ name: e.target.value })
+            setOpen(true)
+          }}
+          onFocus={() => results.length > 0 && setOpen(true)}
+          onBlur={() => setTimeout(() => setOpen(false), 150)}
+        />
+        {open && results.length > 0 && (
+          <ul className="artist-field-results">
+            {results.map((r) => (
+              <li key={r.id}>
+                <button
+                  type="button"
+                  disabled={processing}
+                  onMouseDown={(e) => {
+                    e.preventDefault()
+                    onChange({ artistId: r.id, name: r.name })
+                    setOpen(false)
+                  }}
+                >
+                  {r.name} <span className="muted">({r.id})</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function AdminArtistSplit() {
+  const history = useHistory()
+  const [candidates, setCandidates] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [processing, setProcessing] = useState(false)
+  const [selected, setSelected] = useState(null)
+  const [tracks, setTracks] = useState([])
+  const [tracksLoading, setTracksLoading] = useState(false)
+  const [targets, setTargets] = useState([])
+  const [addState, setAddState] = useState({})
+  const [manualArtist, setManualArtist] = useState({ name: '' })
+
+  const fetchCandidates = useCallback(async () => {
+    setLoading(true)
+    try {
+      const rows = await requestJSONwithCredentials({ url: `${apiURL}/admin/artist-split-candidates` })
+      setCandidates(rows)
+    } catch (e) {
+      console.error(e)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchCandidates()
+  }, [fetchCandidates])
+
+  const loadTracks = useCallback(async (artistId) => {
+    setTracksLoading(true)
+    try {
+      const rows = await requestJSONwithCredentials({ url: `${apiURL}/admin/artists/${artistId}/tracks` })
+      setTracks(rows)
+    } catch (e) {
+      console.error(e)
+    } finally {
+      setTracksLoading(false)
+    }
+  }, [])
+
+  const inspect = async (artist, suggestions) => {
+    setSelected(artist)
+    setAddState({})
+    const initialTargets =
+      suggestions && suggestions.length >= 2 ? suggestions.map((name) => ({ name })) : [{ name: '' }, { name: '' }]
+    setTargets(initialTargets)
+    setTracks([])
+    await loadTracks(artist.id)
+  }
+
+  const inspectManual = async () => {
+    if (!manualArtist.artistId) return
+    await inspect({ id: manualArtist.artistId, name: manualArtist.name }, null)
+    setManualArtist({ name: '' })
+  }
+
+  const ignore = async (artist) => {
+    if (!window.confirm(`Ignore "${artist.name}" (${artist.id})? It will be hidden until it is detected again.`)) return
+    setProcessing(true)
+    try {
+      await requestJSONwithCredentials({
+        url: `${apiURL}/admin/artist-split-candidates/${artist.id}/ignore`,
+        method: 'POST',
+      })
+      setCandidates((prev) => prev.filter((c) => c.id !== artist.id))
+    } catch (e) {
+      console.error(e)
+      window.alert('Ignore failed')
+    } finally {
+      setProcessing(false)
+    }
+  }
+
+  const updateTarget = (index, value) => setTargets((prev) => prev.map((t, i) => (i === index ? value : t)))
+  const addTargetRow = () => setTargets((prev) => [...prev, { name: '' }])
+  const removeTargetRow = (index) => setTargets((prev) => prev.filter((_, i) => i !== index))
+
+  const validTargets = targets
+    .map((t) => (t.artistId ? { artistId: t.artistId, name: t.name } : { name: (t.name || '').trim() }))
+    .filter((t) => t.artistId || t.name)
+
+  const doSplit = async () => {
+    if (validTargets.length < 2) {
+      window.alert('Add at least two artists to split into.')
+      return
+    }
+    const summary = validTargets.map((t) => (t.artistId ? `${t.name} (#${t.artistId})` : `${t.name} (new)`)).join(', ')
+    if (
+      !window.confirm(
+        `Split "${selected.name}" (${selected.id}) into: ${summary}?\n\nEvery track credited to "${selected.name}" will be re-credited to each of these artists, and the combined artist retired.`,
+      )
+    )
+      return
+    setProcessing(true)
+    try {
+      const res = await requestJSONwithCredentials({
+        url: `${apiURL}/admin/artists/${selected.id}/split`,
+        method: 'POST',
+        body: { targets: validTargets.map((t) => (t.artistId ? { artistId: t.artistId } : { name: t.name })) },
+      })
+      window.alert(
+        `Re-credited ${res.trackCount} track${res.trackCount === 1 ? '' : 's'} to ${res.targetArtistIds.length} artists.` +
+          (res.deleted ? ' The combined artist was retired.' : ' The combined artist was kept (it still has followers).'),
+      )
+      setCandidates((prev) => prev.filter((c) => c.id !== selected.id))
+      setSelected(null)
+    } catch (e) {
+      console.error(e)
+      window.alert('Split failed')
+    } finally {
+      setProcessing(false)
+    }
+  }
+
+  const getAdd = (trackId) => addState[trackId] || { target: { name: '' }, role: 'author' }
+  const setAdd = (trackId, next) => setAddState((prev) => ({ ...prev, [trackId]: next }))
+
+  const addCredit = async (track) => {
+    const { target, role } = getAdd(track.id)
+    const body = target.artistId ? { artistId: target.artistId, role } : { name: (target.name || '').trim(), role }
+    if (!body.artistId && !body.name) {
+      window.alert('Pick an existing artist or type a name to add.')
+      return
+    }
+    setProcessing(true)
+    try {
+      await requestJSONwithCredentials({
+        url: `${apiURL}/admin/tracks/${track.id}/credits/add`,
+        method: 'POST',
+        body,
+      })
+      setAdd(track.id, { target: { name: '' }, role: 'author' })
+      await loadTracks(selected.id)
+    } catch (e) {
+      console.error(e)
+      window.alert('Could not add the credit')
+    } finally {
+      setProcessing(false)
+    }
+  }
+
+  const removeCredit = async (track, credit) => {
+    if (!window.confirm(`Remove ${formatCredit(credit)} from "${track.title}"?`)) return
+    setProcessing(true)
+    try {
+      await requestJSONwithCredentials({
+        url: `${apiURL}/admin/tracks/${track.id}/credits/remove`,
+        method: 'POST',
+        body: { artistId: credit.artistId, role: credit.role },
+      })
+      await loadTracks(selected.id)
+    } catch (e) {
+      console.error(e)
+      window.alert('Could not remove the credit')
+    } finally {
+      setProcessing(false)
+    }
+  }
+
+  const renderList = () => (
+    <div className="split-list">
+      <div className="split-manual">
+        <span>Inspect / split any artist:</span>
+        <ArtistField value={manualArtist} onChange={setManualArtist} processing={processing} />
+        <button type="button" disabled={processing || !manualArtist.artistId} onClick={inspectManual}>
+          Inspect
+        </button>
+      </div>
+      {candidates.length === 0 && <div>No suspected combined artists found.</div>}
+      {candidates.map((candidate) => (
+        <div key={candidate.id} className="split-item">
+          <div className="split-info">
+            <div>
+              <strong>{candidate.name}</strong> <span className="muted">({candidate.id})</span>
+            </div>
+            {candidate.detectedName && candidate.detectedName !== candidate.name && (
+              <div className="muted">detected as “{candidate.detectedName}”</div>
+            )}
+            <div className="split-suggestions">
+              {(candidate.suggestions || []).map((s, i) => (
+                <span key={i} className="split-chip">
+                  {s}
+                </span>
+              ))}
+            </div>
+            <div className="muted">
+              {candidate.trackCount} track{candidate.trackCount === 1 ? '' : 's'}
+            </div>
+          </div>
+          <div className="split-actions">
+            <button type="button" disabled={processing} onClick={() => inspect(candidate, candidate.suggestions)}>
+              Inspect
+            </button>
+            <button type="button" disabled={processing} onClick={() => ignore(candidate)}>
+              Ignore
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+
+  const renderDetail = () => (
+    <div className="split-detail">
+      <div className="split-detail-header">
+        <h2>
+          {selected.name} <span className="muted">({selected.id})</span>
+        </h2>
+        <button type="button" disabled={processing} onClick={() => setSelected(null)}>
+          Back to list
+        </button>
+      </div>
+
+      <div className="split-panel">
+        <h3>Split into separate artists</h3>
+        <p className="muted">
+          Each track credited to this artist will be re-credited to all of the artists below; the combined artist is
+          then retired. Pick existing artists or type a name to create a new one.
+        </p>
+        {targets.map((target, index) => (
+          <div key={index} className="split-target-row">
+            <ArtistField
+              value={target}
+              processing={processing}
+              onChange={(value) => updateTarget(index, value)}
+              placeholder="Artist name…"
+            />
+            <button
+              type="button"
+              className="split-target-remove"
+              disabled={processing || targets.length <= 1}
+              onClick={() => removeTargetRow(index)}
+            >
+              ✕
+            </button>
+          </div>
+        ))}
+        <div className="split-panel-actions">
+          <button type="button" disabled={processing} onClick={addTargetRow}>
+            Add artist
+          </button>
+          <button
+            type="button"
+            className="split-primary"
+            disabled={processing || validTargets.length < 2}
+            onClick={doSplit}
+          >
+            Split into {validTargets.length || 0} artists
+          </button>
+        </div>
+      </div>
+
+      <h3>Tracks &amp; credits</h3>
+      {tracksLoading ? (
+        <div>Loading tracks…</div>
+      ) : tracks.length === 0 ? (
+        <div>No tracks are credited to this artist.</div>
+      ) : (
+        <table className="split-tracks">
+          <thead>
+            <tr>
+              <th>Track</th>
+              <th>Release</th>
+              <th>Credits</th>
+              <th>Add credit</th>
+            </tr>
+          </thead>
+          <tbody>
+            {tracks.map((track) => {
+              const add = getAdd(track.id)
+              return (
+                <tr key={track.id}>
+                  <td>
+                    <BandcampLink url={track.trackUrl}>{track.title}</BandcampLink>
+                    {track.version ? ` (${track.version})` : ''}
+                  </td>
+                  <td>
+                    <BandcampLink url={track.releaseUrl}>{track.releaseName || track.releaseUrl || '—'}</BandcampLink>
+                  </td>
+                  <td>
+                    <div className="split-credits">
+                      {(track.credits || []).map((credit) => (
+                        <span key={`${credit.artistId}-${credit.role}`} className="split-credit">
+                          {credit.name} <span className="muted">({credit.role})</span>
+                          <button
+                            type="button"
+                            className="split-credit-remove"
+                            disabled={processing}
+                            title="Remove credit"
+                            onClick={() => removeCredit(track, credit)}
+                          >
+                            ✕
+                          </button>
+                        </span>
+                      ))}
+                    </div>
+                  </td>
+                  <td>
+                    <div className="split-add-credit">
+                      <ArtistField
+                        value={add.target}
+                        processing={processing}
+                        onChange={(value) => setAdd(track.id, { ...add, target: value })}
+                      />
+                      <select
+                        value={add.role}
+                        disabled={processing}
+                        onChange={(e) => setAdd(track.id, { ...add, role: e.target.value })}
+                      >
+                        <option value="author">author</option>
+                        <option value="remixer">remixer</option>
+                      </select>
+                      <button type="button" disabled={processing} onClick={() => addCredit(track)}>
+                        Add
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+
+  return (
+    <div className="page-container scroll-container admin-artist-split">
+      <div className="admin-artist-split-header">
+        <h1>Split Combined Artists</h1>
+        <button className="button button-push_button" onClick={() => history.push('/admin')}>
+          Back to Radiator
+        </button>
+      </div>
+      {loading ? <div>Loading…</div> : selected ? renderDetail() : renderList()}
+    </div>
+  )
+}
+
+export default AdminArtistSplit

--- a/packages/front/src/AdminDatabaseReset.js
+++ b/packages/front/src/AdminDatabaseReset.js
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react'
+import { requestJSONwithCredentials } from './request-json-with-credentials'
+import { apiURL, isPreviewEnv } from './config'
+
+// Preview-only "danger zone" that wipes and rebuilds the database. Rendered
+// only when the client build is a preview AND the server reports the capability
+// (the server is authoritative; this is just to avoid showing a dead control).
+// Resetting requires typing the exact environment name, then a final confirm.
+export default function AdminDatabaseReset() {
+  const [capability, setCapability] = useState(null)
+  const [typed, setTyped] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    if (!isPreviewEnv) return
+    requestJSONwithCredentials({ url: `${apiURL}/admin/capabilities` })
+      .then(setCapability)
+      .catch((e) => console.error('Failed to load admin capabilities', e))
+  }, [])
+
+  if (!isPreviewEnv || !capability || !capability.databaseReset) return null
+
+  const envName = capability.environmentName
+  const armed = typed.trim() === envName && !busy
+
+  const reset = async () => {
+    if (typed.trim() !== envName) return
+    if (
+      !window.confirm(
+        `This permanently deletes ALL data in "${envName}" and rebuilds an empty database. ` +
+          'This cannot be undone. Continue?',
+      )
+    )
+      return
+    setBusy(true)
+    try {
+      await requestJSONwithCredentials({
+        url: `${apiURL}/admin/reset-database`,
+        method: 'POST',
+        body: { confirm: typed.trim() },
+      })
+      window.alert('Database reset complete. You will likely need to sign in again.')
+      window.location.reload()
+    } catch (e) {
+      console.error(e)
+      window.alert('Database reset failed. Check the server logs.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="admin-danger-zone">
+      <h2>Danger zone — preview only</h2>
+      <p>
+        Reset the <strong>{envName}</strong> database: permanently deletes all data and rebuilds an empty schema by
+        re-running every migration. Not available in production.
+      </p>
+      <div className="admin-danger-zone-controls">
+        <label htmlFor="admin-db-reset-confirm">
+          Type <code>{envName}</code> to enable:
+        </label>
+        <input
+          id="admin-db-reset-confirm"
+          type="text"
+          autoComplete="off"
+          spellCheck={false}
+          placeholder={envName}
+          value={typed}
+          disabled={busy}
+          onChange={(e) => setTyped(e.target.value)}
+        />
+        <button className="button button-push_button admin-db-reset-button" disabled={!armed} onClick={reset}>
+          {busy ? 'Resetting…' : 'Reset database'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/packages/front/src/AdminMislabeled.css
+++ b/packages/front/src/AdminMislabeled.css
@@ -266,6 +266,12 @@
   background: #444;
 }
 
+.mislabeled-results li button.mislabeled-create-option {
+  border-top: 1px solid #555;
+  font-style: italic;
+  color: #9ad;
+}
+
 @media (max-width: 768px) {
   .mislabeled-tracks,
   .mislabeled-tracks thead,

--- a/packages/front/src/AdminMislabeled.js
+++ b/packages/front/src/AdminMislabeled.js
@@ -81,6 +81,12 @@ function EntityPicker({ onPick, processing, fixedType }) {
     }
   }, [query, targetType])
 
+  // Only artists can be created on the fly here; the label reassign path
+  // requires an existing label id.
+  const trimmed = query.trim()
+  const canCreate = targetType === 'artist' && trimmed !== ''
+  const exactMatch = results.some((r) => r.name.toLowerCase() === trimmed.toLowerCase())
+
   return (
     <div className="mislabeled-picker">
       {!fixedType && (
@@ -95,10 +101,10 @@ function EntityPicker({ onPick, processing, fixedType }) {
           placeholder={`Search ${targetType}…`}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          onFocus={() => results.length > 0 && setOpen(true)}
+          onFocus={() => (results.length > 0 || canCreate) && setOpen(true)}
           disabled={processing}
         />
-        {open && results.length > 0 && (
+        {open && (results.length > 0 || canCreate) && (
           <ul className="mislabeled-results">
             {results.map((r) => (
               <li key={r.id}>
@@ -115,6 +121,22 @@ function EntityPicker({ onPick, processing, fixedType }) {
                 </button>
               </li>
             ))}
+            {canCreate && !exactMatch && (
+              <li>
+                <button
+                  type="button"
+                  className="mislabeled-create-option"
+                  disabled={processing}
+                  onClick={() => {
+                    setOpen(false)
+                    setQuery('')
+                    onPick({ targetType, targetName: trimmed })
+                  }}
+                >
+                  ＋ Create new artist “{trimmed}”
+                </button>
+              </li>
+            )}
           </ul>
         )}
       </div>
@@ -183,7 +205,9 @@ function AdminMislabeled() {
   const reassign = async (track, { targetType, targetId, targetName }) => {
     if (
       !window.confirm(
-        `Reassign "${track.title}" from ${type} "${selected.name}" to ${targetType} "${targetName}" (${targetId})?`,
+        `Reassign "${track.title}" from ${type} "${selected.name}" to ${targetType} "${targetName}" ${
+          targetId ? `(${targetId})` : '(new)'
+        }?`,
       )
     )
       return
@@ -192,7 +216,7 @@ function AdminMislabeled() {
       await requestJSONwithCredentials({
         url: `${apiURL}/admin/mislabeled/reassign`,
         method: 'POST',
-        body: { sourceType: type, sourceId: selected.id, targetType, targetId, trackId: track.id, role: track.role },
+        body: { sourceType: type, sourceId: selected.id, targetType, targetId, targetName, trackId: track.id, role: track.role },
       })
       setTracks((prev) => prev.filter((t) => t.id !== track.id))
     } catch (e) {
@@ -208,7 +232,7 @@ function AdminMislabeled() {
       !window.confirm(
         `Reassign all ${group.tracks.length} track${group.tracks.length === 1 ? '' : 's'} of "${
           group.releaseName || group.releaseUrl || 'this release'
-        }" from ${type} "${selected.name}" to ${targetType} "${targetName}" (${targetId})?`,
+        }" from ${type} "${selected.name}" to ${targetType} "${targetName}" ${targetId ? `(${targetId})` : '(new)'}?`,
       )
     )
       return
@@ -217,7 +241,7 @@ function AdminMislabeled() {
       await requestJSONwithCredentials({
         url: `${apiURL}/admin/mislabeled/reassign-release`,
         method: 'POST',
-        body: { sourceType: type, sourceId: selected.id, targetType, targetId, releaseId: group.releaseId },
+        body: { sourceType: type, sourceId: selected.id, targetType, targetId, targetName, releaseId: group.releaseId },
       })
       const reassignedIds = new Set(group.tracks.map((t) => t.id))
       setTracks((prev) => prev.filter((t) => !reassignedIds.has(t.id)))
@@ -634,7 +658,8 @@ function AdminMislabeled() {
             <li>
               <strong>Reassign to</strong> (single track) / <strong>Reassign all tracks to</strong> (whole release):
               moves the track(s) to the artist or label they really belong to — each track gains the chosen credit and
-              loses this one.
+              loses this one. Pick an existing artist/label, or type a name and choose “Create new artist” to reassign
+              to a brand-new artist.
             </li>
             {type === 'artist' && (
               <li>

--- a/packages/front/src/App.js
+++ b/packages/front/src/App.js
@@ -10,6 +10,7 @@ import Spinner from './Spinner.js'
 import Admin from './Admin.js'
 import AdminDuplicates from './AdminDuplicates.js'
 import AdminMislabeled from './AdminMislabeled.js'
+import AdminArtistSplit from './AdminArtistSplit.js'
 import AdminJobs from './AdminJobs.js'
 import { launchMessages } from './launchMessages'
 
@@ -1222,6 +1223,9 @@ class App extends Component {
                 </Route>
                 <Route exact path="/admin/mislabeled">
                   <AdminMislabeled />
+                </Route>
+                <Route exact path="/admin/artist-split">
+                  <AdminArtistSplit />
                 </Route>
                 <Route exact path="/admin/jobs">
                   <AdminJobs />


### PR DESCRIPTION
Adds detection + admin tooling to split an artist record that actually
bundles several artists (e.g. a Bandcamp byline "Sleepnet & Lumen" stored
as one artist) into the real individual artists.

- detectArtistSplitCandidates job flags artists whose name contains a
  separator (&, comma, " x ", featuring, feat., vs, /, ...) into a new
  artist_split_candidate table; detection is permissive and admin-driven
  so legitimate compound names ("Camo & Krooked") can be ignored.
- Admin "Split Combined Artists" page lists candidates with suggested
  parts, supports Ignore, and an inspect view to split an artist into
  existing and/or newly created artists (re-crediting every track,
  carrying genres over, and retiring the emptied source).
- Inspect view also allows adding and removing individual artist credits
  per track.
- Parsing heuristics are pure and unit tested.

https://claude.ai/code/session_019DMPFAfis2qhcG3mAYBTru

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New "Split Artists" admin page (nav button, UI & styling) to inspect candidates, choose targets, and perform splits
  * Manual per-track credit add/remove controls with confirmation flows
  * Preview-only "Reset database" danger zone UI to trigger environment-guarded resets
  * Option to create a new artist from inline search when reassigning

* **Database**
  * New table to store artist-split candidates and a daily scheduled detector job

* **Tests**
  * Added unit tests for split-detection logic and reset-policy validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gadgetmies/fomoplayer/pull/371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->