### PR TITLE
Allow reassigning tracks to multiple artists at once

### DIFF
--- a/packages/back/routes/admin/db.js
+++ b/packages/back/routes/admin/db.js
@@ -1032,39 +1032,48 @@ module.exports.getMislabeledEntityTracks = async (type, id) => {
   )
 }
 
-// Move one track's link from a mislabeled source entity to the correct target.
-// Source and target may be different types (e.g. a label-as-artist track moved
-// onto a label): we add the target link and drop the source link.
-module.exports.reassignTrack = async ({ sourceType, sourceId, targetType, targetId, targetName, trackId, role }) => {
-  if (!MISLABELED_ENTITY_TYPES.includes(sourceType) || !MISLABELED_ENTITY_TYPES.includes(targetType)) {
+// Move one track's link from a mislabeled source entity to one or more correct
+// targets. `targets` is an array of { targetType, targetId, targetName }; each
+// target may be a different type from the source (e.g. a label-as-artist track
+// moved onto a label). We add every target link and then drop the single source
+// link, all in one transaction. Passing several artist targets re-credits the
+// track to a collaboration instead of moving it to a single artist.
+module.exports.reassignTrack = async ({ sourceType, sourceId, targets, trackId, role }) => {
+  if (!MISLABELED_ENTITY_TYPES.includes(sourceType)) throw new Error('Invalid entity type')
+  if (!Array.isArray(targets) || targets.length === 0) throw new Error('Pick at least one target')
+  if (targets.some(({ targetType }) => !MISLABELED_ENTITY_TYPES.includes(targetType))) {
     throw new Error('Invalid entity type')
   }
   const src = parseInt(sourceId, 10)
   const track = parseInt(trackId, 10)
   if ([src, track].some((n) => Number.isNaN(n))) throw new Error('Invalid id')
-  const hasTargetId = targetId != null && targetId !== ''
-  if (targetType === 'label' && !hasTargetId) throw new Error('Pick an existing label to reassign to')
 
-  const targetRole = targetType === 'artist' ? role || 'author' : null
-  let tgt
+  const added = []
   await BPromise.using(pg.getTransaction(), async (tx) => {
-    tgt =
-      targetType === 'artist'
-        ? await resolveTargetArtistId(tx, hasTargetId ? { artistId: targetId } : { name: targetName })
-        : parseInt(targetId, 10)
-    if (Number.isNaN(tgt)) throw new Error('Invalid id')
-    if (sourceType === targetType && src === tgt) throw new Error('Source and target are the same entity')
+    for (const { targetType, targetId, targetName } of targets) {
+      const hasTargetId = targetId != null && targetId !== ''
+      if (targetType === 'label' && !hasTargetId) throw new Error('Pick an existing label to reassign to')
 
-    if (targetType === 'artist') {
-      await tx.queryAsync(sql`-- reassignTrack add artist
-        INSERT INTO track__artist (track_id, artist_id, track__artist_role)
-        VALUES (${track}, ${tgt}, ${targetRole})
-        ON CONFLICT ON CONSTRAINT track__artist_track_id_artist_id_track__artist_role_key DO NOTHING`)
-    } else {
-      await tx.queryAsync(sql`-- reassignTrack add label
-        INSERT INTO track__label (track_id, label_id)
-        VALUES (${track}, ${tgt})
-        ON CONFLICT ON CONSTRAINT track__label_track_id_label_id_key DO NOTHING`)
+      const targetRole = targetType === 'artist' ? role || 'author' : null
+      const tgt =
+        targetType === 'artist'
+          ? await resolveTargetArtistId(tx, hasTargetId ? { artistId: targetId } : { name: targetName })
+          : parseInt(targetId, 10)
+      if (Number.isNaN(tgt)) throw new Error('Invalid id')
+      if (sourceType === targetType && src === tgt) throw new Error('Source and target are the same entity')
+
+      if (targetType === 'artist') {
+        await tx.queryAsync(sql`-- reassignTrack add artist
+          INSERT INTO track__artist (track_id, artist_id, track__artist_role)
+          VALUES (${track}, ${tgt}, ${targetRole})
+          ON CONFLICT ON CONSTRAINT track__artist_track_id_artist_id_track__artist_role_key DO NOTHING`)
+      } else {
+        await tx.queryAsync(sql`-- reassignTrack add label
+          INSERT INTO track__label (track_id, label_id)
+          VALUES (${track}, ${tgt})
+          ON CONFLICT ON CONSTRAINT track__label_track_id_label_id_key DO NOTHING`)
+      }
+      added.push({ type: targetType, id: tgt, role: targetRole })
     }
 
     if (sourceType === 'artist') {
@@ -1080,17 +1089,17 @@ module.exports.reassignTrack = async ({ sourceType, sourceId, targetType, target
         DELETE FROM track__label WHERE track_id = ${track} AND label_id = ${src}`)
     }
 
-    // Rebuild the cached track_details JSON so search reflects the new credit
-    // instead of the old one.
+    // Rebuild the cached track_details JSON so search reflects the new credits
+    // instead of the old ones.
     await refreshTrackDetails(tx, [track])
   })
 
-  // Revert by removing the added {targetType targetId} link from track ${track}
-  // and re-adding the {sourceType sourceId} link (role ${role || 'n/a'}).
-  logger.info(`reassignTrack: track ${track} ${sourceType} ${src} -> ${targetType} ${tgt}`, {
+  // Revert by removing each added link from track ${track} and re-adding the
+  // {sourceType sourceId} link (role ${role || 'n/a'}).
+  logger.info(`reassignTrack: track ${track} ${sourceType} ${src} -> ${added.map((a) => `${a.type} ${a.id}`).join(', ')}`, {
     operation: 'reassignTrack',
     trackId: track,
-    added: { type: targetType, id: tgt, role: targetRole },
+    added,
     removed: { type: sourceType, id: src, role: sourceType === 'artist' ? role || null : null },
   })
 }

--- a/packages/front/src/AdminMislabeled.css
+++ b/packages/front/src/AdminMislabeled.css
@@ -211,6 +211,67 @@
   border: 1px solid #3c5a3c;
 }
 
+.mislabeled-reassign {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
+}
+
+.mislabeled-targets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mislabeled-targets li {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 4px 2px 8px;
+  background: #2a3a4a;
+  border: 1px solid #3c5a6a;
+  border-radius: 12px;
+  font-size: 0.85em;
+}
+
+.mislabeled-target-remove {
+  padding: 0 6px;
+  line-height: 1.4;
+  background: transparent;
+  color: #ccc;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.mislabeled-target-remove:hover {
+  background: #44566a;
+  color: white;
+}
+
+.mislabeled-target-remove:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.mislabeled-reassign-apply {
+  padding: 6px 12px;
+  background: var(--fp-brand-primary, #007bff);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.mislabeled-reassign-apply:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 .mislabeled-picker {
   display: flex;
   gap: 6px;

--- a/packages/front/src/AdminMislabeled.js
+++ b/packages/front/src/AdminMislabeled.js
@@ -144,6 +144,59 @@ function EntityPicker({ onPick, processing, fixedType }) {
   )
 }
 
+// Pick one or more reassignment targets for a single track, then apply them all
+// at once. Each picked target shows as a removable chip; choosing several
+// artists re-credits the track to a collaboration rather than moving it to a
+// single artist. Applying clears the pending list via the `onApplied` callback.
+function TrackReassign({ onReassign, processing }) {
+  const [targets, setTargets] = useState([])
+
+  const addTarget = (target) =>
+    setTargets((prev) =>
+      prev.some(
+        (t) => t.targetType === target.targetType && t.targetId === target.targetId && t.targetName === target.targetName,
+      )
+        ? prev
+        : [...prev, target],
+    )
+
+  return (
+    <div className="mislabeled-reassign">
+      {targets.length > 0 && (
+        <ul className="mislabeled-targets">
+          {targets.map((t, i) => (
+            <li key={`${t.targetType}:${t.targetId ?? 'new'}:${t.targetName}`}>
+              <span>
+                {t.targetName} <span className="muted">{t.targetId ? `(${t.targetId})` : '(new)'} · {t.targetType}</span>
+              </span>
+              <button
+                type="button"
+                className="mislabeled-target-remove"
+                disabled={processing}
+                aria-label={`Remove ${t.targetName}`}
+                onClick={() => setTargets((prev) => prev.filter((_, idx) => idx !== i))}
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <EntityPicker processing={processing} onPick={addTarget} />
+      {targets.length > 0 && (
+        <button
+          type="button"
+          className="mislabeled-reassign-apply"
+          disabled={processing}
+          onClick={() => onReassign(targets, () => setTargets([]))}
+        >
+          Reassign to {targets.length} {targets.length === 1 ? 'target' : 'targets'}
+        </button>
+      )}
+    </div>
+  )
+}
+
 function AdminMislabeled() {
   const history = useHistory()
   const [type, setType] = useState('artist')
@@ -202,23 +255,20 @@ function AdminMislabeled() {
     }
   }
 
-  const reassign = async (track, { targetType, targetId, targetName }) => {
-    if (
-      !window.confirm(
-        `Reassign "${track.title}" from ${type} "${selected.name}" to ${targetType} "${targetName}" ${
-          targetId ? `(${targetId})` : '(new)'
-        }?`,
-      )
-    )
-      return
+  const reassign = async (track, targets, onApplied) => {
+    const targetList = targets
+      .map(({ targetType, targetId, targetName }) => `${targetType} "${targetName}" ${targetId ? `(${targetId})` : '(new)'}`)
+      .join(', ')
+    if (!window.confirm(`Reassign "${track.title}" from ${type} "${selected.name}" to ${targetList}?`)) return
     setProcessing(true)
     try {
       await requestJSONwithCredentials({
         url: `${apiURL}/admin/mislabeled/reassign`,
         method: 'POST',
-        body: { sourceType: type, sourceId: selected.id, targetType, targetId, targetName, trackId: track.id, role: track.role },
+        body: { sourceType: type, sourceId: selected.id, targets, trackId: track.id, role: track.role },
       })
       setTracks((prev) => prev.filter((t) => t.id !== track.id))
+      if (onApplied) onApplied()
     } catch (e) {
       console.error(e)
       window.alert('Reassign failed')
@@ -657,9 +707,10 @@ function AdminMislabeled() {
           <ul>
             <li>
               <strong>Reassign to</strong> (single track) / <strong>Reassign all tracks to</strong> (whole release):
-              moves the track(s) to the artist or label they really belong to — each track gains the chosen credit and
-              loses this one. Pick an existing artist/label, or type a name and choose “Create new artist” to reassign
-              to a brand-new artist.
+              moves the track(s) to the artist(s) or label they really belong to — each track gains the chosen credit(s)
+              and loses this one. Pick an existing artist/label, or type a name and choose “Create new artist” to
+              reassign to a brand-new artist. For a single track you can add several targets before applying to credit it
+              to multiple artists (a collaboration) at once.
             </li>
             {type === 'artist' && (
               <li>
@@ -727,7 +778,10 @@ function AdminMislabeled() {
                       </td>
                       <td className="muted">{formatArtists(track.artists)}</td>
                       <td>
-                        <EntityPicker processing={processing} onPick={(target) => reassign(track, target)} />
+                        <TrackReassign
+                          processing={processing}
+                          onReassign={(targets, onApplied) => reassign(track, targets, onApplied)}
+                        />
                       </td>
                     </tr>
                   ))}


### PR DESCRIPTION
## Summary

- Add `TrackReassign` component that lets users select multiple reassignment targets for a single track before applying them all at once
- Update backend `reassignTrack` to accept an array of targets instead of a single target, enabling collaboration credits in one operation
- Add UI for managing target chips with remove buttons and an apply button that triggers the reassignment

## Test plan

- Verify that selecting a single target and applying works as before
- Verify that selecting multiple artist targets and applying creates a collaboration credit on the track
- Verify that removing a target from the list works correctly
- Verify that the apply button is disabled while processing
- Verify that the confirmation dialog shows all selected targets
- Verify that reassigning to a label still requires an existing label (not a new one)
- Verify that the track is removed from the mislabeled list after successful reassignment

https://claude.ai/code/session_01Lrg7fgaoZp22Q4u9qyQEiz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin track reassignment now supports multiple targets, allowing users to reassign a track to several artists or labels simultaneously in a single operation.
  * Updated interface displays selected targets as removable chips with streamlined workflow for managing multiple reassignments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gadgetmies/fomoplayer/pull/372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->