### PR TITLE
Add HNSW index for track preview embedding similarity search

### DIFF
--- a/packages/back/migrations/20260531215832-add-track-preview-embedding-ann-index.js
+++ b/packages/back/migrations/20260531215832-add-track-preview-embedding-ann-index.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20260531215832-add-track-preview-embedding-ann-index-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+
+      if (db.log.isSilent !== true) {
+        console.log('received data: ' + data)
+      }
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20260531215832-add-track-preview-embedding-ann-index-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      if (db.log.isSilent !== true) {
+        console.log('received data: ' + data)
+      }
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/packages/back/migrations/sqls/20260531215832-add-track-preview-embedding-ann-index-down.sql
+++ b/packages/back/migrations/sqls/20260531215832-add-track-preview-embedding-ann-index-down.sql
@@ -1,0 +1,2 @@
+DROP INDEX idx_store__track_preview_embedding_hnsw_cosine
+;

--- a/packages/back/migrations/sqls/20260531215832-add-track-preview-embedding-ann-index-up.sql
+++ b/packages/back/migrations/sqls/20260531215832-add-track-preview-embedding-ann-index-up.sql
@@ -1,0 +1,11 @@
+-- Approximate-nearest-neighbour index backing the similarity search in
+-- routes/shared/db/search.js, which sorts by cosine distance
+--   store__track_preview_embedding <=> reference_embedding
+-- HNSW gives sub-linear ORDER BY ... <=> ... scans and matches the cosine
+-- operator class (vector_cosine_ops) used by <=>. A full (non-partial) index
+-- is used so the planner can always satisfy the ordering, even when the
+-- embedding_type filter is supplied as a bind parameter.
+CREATE INDEX idx_store__track_preview_embedding_hnsw_cosine
+  ON store__track_preview_embedding
+  USING hnsw (store__track_preview_embedding vector_cosine_ops)
+;


### PR DESCRIPTION
## Summary

- Add database migration to create an HNSW (Hierarchical Navigable Small World) approximate-nearest-neighbor index on the `store__track_preview_embedding` column
- Index uses the `vector_cosine_ops` operator class to support cosine distance ordering for similarity search queries
- Full (non-partial) index ensures the query planner can always use it for `ORDER BY <=>` operations, even with filter parameters

## Test plan

- Verify migration runs successfully: `npm run migrate up`
- Verify rollback works: `npm run migrate down`
- Confirm index exists in database: `\d store__track_preview_embedding` (PostgreSQL)
- Existing similarity search queries in `routes/shared/db/search.js` should benefit from improved performance on large embedding datasets

## Sentry

```sentry-also-resolves
```

https://claude.ai/code/session_012zZS3rgkyta93UzxpWsXGE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized track preview embedding search performance through database indexing enhancements using approximate nearest-neighbor algorithms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->