### PR TITLE
Fix demo video recording flush in cascade-test runner

### DIFF
--- a/.github/workflows/pr-demo-local.yml
+++ b/.github/workflows/pr-demo-local.yml
@@ -108,6 +108,21 @@ jobs:
           TEST_REGEX="$(basename "$TEST_FILE" | sed 's/\./\\./g')$"
           yarn workspace fomoplayer_back ci:demo "$TEST_DIR" --regex "$TEST_REGEX"
 
+      # Guard against a regression of the zero-byte-video bug: Playwright only
+      # flushes a recording when its context/browser closes, so if that ever
+      # stops happening we want the job to fail here rather than silently upload
+      # an empty artifact.
+      - name: Verify recording is non-empty
+        run: |
+          DIR="${{ github.workspace }}/demo-output"
+          if ! find "$DIR" -type f -name '*.webm' -size +0c | grep -q .; then
+            echo "::error::No non-empty video was recorded in ${DIR} — the demo recording produced zero-byte output."
+            ls -la "$DIR" || true
+            exit 1
+          fi
+          echo "Recorded videos:"
+          find "$DIR" -type f -name '*.webm' -printf '%s\t%p\n'
+
       - name: Upload demo video
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-demo-local.yml
+++ b/.github/workflows/pr-demo-local.yml
@@ -129,17 +129,26 @@ jobs:
       - name: Collect recording diagnostics
         if: always()
         run: |
-          DIR="${{ github.workspace }}/demo-output"
           {
             echo "DEMO_DIAG<<DIAG_EOF"
-            echo "demo-output listing:"
-            ls -laR "$DIR" 2>&1 || echo "(demo-output missing)"
+            echo "context github.workspace = ${{ github.workspace }}"
+            echo "env GITHUB_WORKSPACE     = ${GITHUB_WORKSPACE}"
+            echo "pwd                      = $(pwd)"
             echo ""
-            echo "webm files and sizes:"
-            find "$DIR" -type f -name '*.webm' -printf '%s bytes\t%p\n' 2>&1 || echo "(none)"
+            echo "ls of \${{ github.workspace }}/demo-output:"
+            ls -laR "${{ github.workspace }}/demo-output" 2>&1 || echo "(missing)"
             echo ""
-            echo "stray Playwright video temp dirs under the workspace:"
-            find "${{ github.workspace }}" -type d -name '.playwright-artifacts-*' 2>/dev/null || true
+            echo "ls of \$GITHUB_WORKSPACE/demo-output:"
+            ls -laR "${GITHUB_WORKSPACE}/demo-output" 2>&1 || echo "(missing)"
+            echo ""
+            echo "ALL *.webm anywhere in the container:"
+            find / -type f -name '*.webm' 2>/dev/null | head -50 || true
+            echo ""
+            echo "ALL demo-output dirs anywhere in the container:"
+            find / -type d -name 'demo-output' 2>/dev/null | head -50 || true
+            echo ""
+            echo "ALL Playwright video temp dirs in the container:"
+            find / -type d -name '.playwright-artifacts-*' 2>/dev/null | head -50 || true
             echo "DIAG_EOF"
           } >> "$GITHUB_ENV"
 

--- a/.github/workflows/pr-demo-local.yml
+++ b/.github/workflows/pr-demo-local.yml
@@ -96,13 +96,21 @@ jobs:
       # Record the test in demo mode: VIDEO_DIR enables recording, and setup.js
       # turns on slow-mo + the cursor/click/keyboard overlay whenever VIDEO_DIR
       # is set. No PREVIEW_URL, so the test runs against the local backend.
+      # NOTE: this is a container job, so use the $GITHUB_WORKSPACE env var (the
+      # workspace path *inside* the container, e.g. /__w/<repo>/<repo>) rather
+      # than the ${{ github.workspace }} expression, which expands to the *host*
+      # path (/home/runner/work/...). The runner path-translates env/inputs into
+      # the container but does NOT rewrite ${{ github.workspace }} substituted as
+      # a literal string inside a run: script — mixing the two made the recording
+      # land under $GITHUB_WORKSPACE while the verify step looked at the host path
+      # and falsely reported a zero-byte recording.
       - name: Record demo test
         env:
           DATABASE_URL: postgres://postgres:postgres@postgres/multi-store-player-test
           REACT_APP_ENV: ci
-          VIDEO_DIR: ${{ github.workspace }}/demo-output
           PW_SLOWMO: '600'
         run: |
+          export VIDEO_DIR="$GITHUB_WORKSPACE/demo-output"
           TEST_FILE="${{ steps.demo.outputs.test_file }}"
           TEST_DIR=$(dirname "$TEST_FILE")
           TEST_REGEX="$(basename "$TEST_FILE" | sed 's/\./\\./g')$"
@@ -114,7 +122,7 @@ jobs:
       # an empty artifact.
       - name: Verify recording is non-empty
         run: |
-          DIR="${{ github.workspace }}/demo-output"
+          DIR="$GITHUB_WORKSPACE/demo-output"
           if ! find "$DIR" -type f -name '*.webm' -size +0c | grep -q .; then
             echo "::error::No non-empty video was recorded in ${DIR} — the demo recording produced zero-byte output."
             ls -la "$DIR" || true
@@ -123,32 +131,19 @@ jobs:
           echo "Recorded videos:"
           find "$DIR" -type f -name '*.webm' -printf '%s\t%p\n'
 
-      # Capture exactly what landed in demo-output (and any Playwright temp
-      # artifacts) so the PR comment can surface it — handy when a recording is
-      # empty/missing and the raw run logs aren't readily accessible.
+      # Surface what landed in demo-output in the PR comment — handy when a
+      # recording is empty/missing and the raw run logs aren't readily accessible.
       - name: Collect recording diagnostics
         if: always()
         run: |
+          DIR="$GITHUB_WORKSPACE/demo-output"
           {
             echo "DEMO_DIAG<<DIAG_EOF"
-            echo "context github.workspace = ${{ github.workspace }}"
-            echo "env GITHUB_WORKSPACE     = ${GITHUB_WORKSPACE}"
-            echo "pwd                      = $(pwd)"
+            echo "recording dir: ${DIR}"
+            ls -laR "$DIR" 2>&1 || echo "(demo-output missing)"
             echo ""
-            echo "ls of \${{ github.workspace }}/demo-output:"
-            ls -laR "${{ github.workspace }}/demo-output" 2>&1 || echo "(missing)"
-            echo ""
-            echo "ls of \$GITHUB_WORKSPACE/demo-output:"
-            ls -laR "${GITHUB_WORKSPACE}/demo-output" 2>&1 || echo "(missing)"
-            echo ""
-            echo "ALL *.webm anywhere in the container:"
-            find / -type f -name '*.webm' 2>/dev/null | head -50 || true
-            echo ""
-            echo "ALL demo-output dirs anywhere in the container:"
-            find / -type d -name 'demo-output' 2>/dev/null | head -50 || true
-            echo ""
-            echo "ALL Playwright video temp dirs in the container:"
-            find / -type d -name '.playwright-artifacts-*' 2>/dev/null | head -50 || true
+            echo "webm files and sizes:"
+            find "$DIR" -type f -name '*.webm' -printf '%s bytes\t%p\n' 2>&1 || echo "(none)"
             echo "DIAG_EOF"
           } >> "$GITHUB_ENV"
 

--- a/.github/workflows/pr-demo-local.yml
+++ b/.github/workflows/pr-demo-local.yml
@@ -123,6 +123,26 @@ jobs:
           echo "Recorded videos:"
           find "$DIR" -type f -name '*.webm' -printf '%s\t%p\n'
 
+      # Capture exactly what landed in demo-output (and any Playwright temp
+      # artifacts) so the PR comment can surface it — handy when a recording is
+      # empty/missing and the raw run logs aren't readily accessible.
+      - name: Collect recording diagnostics
+        if: always()
+        run: |
+          DIR="${{ github.workspace }}/demo-output"
+          {
+            echo "DEMO_DIAG<<DIAG_EOF"
+            echo "demo-output listing:"
+            ls -laR "$DIR" 2>&1 || echo "(demo-output missing)"
+            echo ""
+            echo "webm files and sizes:"
+            find "$DIR" -type f -name '*.webm' -printf '%s bytes\t%p\n' 2>&1 || echo "(none)"
+            echo ""
+            echo "stray Playwright video temp dirs under the workspace:"
+            find "${{ github.workspace }}" -type d -name '.playwright-artifacts-*' 2>/dev/null || true
+            echo "DIAG_EOF"
+          } >> "$GITHUB_ENV"
+
       - name: Upload demo video
         if: always()
         uses: actions/upload-artifact@v4
@@ -139,6 +159,7 @@ jobs:
             const succeeded = '${{ job.status }}' === 'success'
             const icon = succeeded ? '✅' : '❌'
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            const diag = process.env.DEMO_DIAG || '(no diagnostics captured)'
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -151,5 +172,12 @@ jobs:
                 succeeded
                   ? 'Download the `demo-local-pr-${{ github.event.pull_request.number }}` artifact from the run page to watch the video.'
                   : 'Check the run logs for details.',
+                '',
+                '<details><summary>Recording diagnostics</summary>',
+                '',
+                '```',
+                diag,
+                '```',
+                '</details>',
               ].join('\n'),
             })

--- a/.github/workflows/pr-demo-preview.yml
+++ b/.github/workflows/pr-demo-preview.yml
@@ -126,6 +126,21 @@ jobs:
           TEST_REGEX="$(basename "$TEST_FILE" | sed 's/\./\\./g')$"
           yarn ci:demo "$TEST_DIR" --regex "$TEST_REGEX"
 
+      # Guard against a regression of the zero-byte-video bug: Playwright only
+      # flushes a recording when its context/browser closes, so if that ever
+      # stops happening we want the job to fail here rather than silently upload
+      # an empty artifact.
+      - name: Verify recording is non-empty
+        run: |
+          DIR="${{ github.workspace }}/demo-output"
+          if ! find "$DIR" -type f -name '*.webm' -size +0c | grep -q .; then
+            echo "::error::No non-empty video was recorded in ${DIR} — the demo recording produced zero-byte output."
+            ls -la "$DIR" || true
+            exit 1
+          fi
+          echo "Recorded videos:"
+          find "$DIR" -type f -name '*.webm' -printf '%s\t%p\n'
+
       # ── 7. Upload the recorded video ──────────────────────────────────────
       - name: Upload demo video
         if: always()

--- a/packages/back/test/browser/admin-radiator-local.js
+++ b/packages/back/test/browser/admin-radiator-local.js
@@ -1,13 +1,14 @@
 // Local demo (demo-test workflow): seeds the database directly, since the test
 // drives a backend running in the same environment.
 const { test } = require('cascade-test')
-const { getSharedContext } = require('../lib/setup')
+const { getSharedContext, teardownSharedContext } = require('../lib/setup')
 const { seedTracks } = require('../lib/seed')
 const { resolveTestUserId } = require('../lib/test-user')
 const { seedRadiatorPresetsViaDb, runRadiatorJobsViaDb } = require('../lib/radiator-mock')
 const { gotoRadiator, assertRadiatorShowsSeededData } = require('../lib/admin-radiator-steps')
 
 test({
+  teardown: teardownSharedContext,
   setup: async () => {
     const { page } = await getSharedContext()
     const userId = await resolveTestUserId()

--- a/packages/back/test/browser/admin-radiator-preview.js
+++ b/packages/back/test/browser/admin-radiator-preview.js
@@ -4,13 +4,14 @@
 // the /admin endpoints (the preview Actions bot is granted admin from its OIDC
 // sub; otherwise ADMIN_USER_SUBS must list the user's subject).
 const { test } = require('cascade-test')
-const { getSharedContext } = require('../lib/setup')
+const { getSharedContext, teardownSharedContext } = require('../lib/setup')
 const { seedTracks } = require('../lib/seed')
 const { resolveTestUserId } = require('../lib/test-user')
 const { seedRadiatorPresetsViaApi, runRadiatorJobsViaApi } = require('../lib/radiator-mock')
 const { gotoRadiator, assertRadiatorShowsSeededData } = require('../lib/admin-radiator-steps')
 
 test({
+  teardown: teardownSharedContext,
   setup: async () => {
     const { page } = await getSharedContext()
     const userId = await resolveTestUserId()

--- a/packages/back/test/browser/browsing.js
+++ b/packages/back/test/browser/browsing.js
@@ -1,10 +1,11 @@
 const { expect } = require('chai')
 const { test } = require('cascade-test')
-const { getSharedContext, dismissOnboarding, waitForWithTimeoutMessage } = require('../lib/setup')
+const { getSharedContext, dismissOnboarding, waitForWithTimeoutMessage, teardownSharedContext } = require('../lib/setup')
 const { seedTracks, seededTrackAssertions } = require('../lib/seed')
 const { resolveTestUserId } = require('../lib/test-user')
 
 test({
+  teardown: teardownSharedContext,
   setup: async () => {
     const { page } = await getSharedContext()
     const userId = await resolveTestUserId()

--- a/packages/back/test/browser/carts.js
+++ b/packages/back/test/browser/carts.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai')
 const { test } = require('cascade-test')
-const { getSharedContext, dismissOnboarding, waitForWithTimeoutMessage } = require('../lib/setup')
+const { getSharedContext, dismissOnboarding, waitForWithTimeoutMessage, teardownSharedContext } = require('../lib/setup')
 const { seedTracks } = require('../lib/seed')
 const { resolveTestUserId } = require('../lib/test-user')
 
@@ -91,6 +91,7 @@ const openDefaultCart = async (page) => {
 }
 
 test({
+  teardown: teardownSharedContext,
   setup: async () => {
     const { page } = await getSharedContext()
     const userId = await resolveTestUserId()

--- a/packages/back/test/browser/playback.js
+++ b/packages/back/test/browser/playback.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai')
 const { test } = require('cascade-test')
-const { getSharedContext, dismissOnboarding, waitForWithTimeoutMessage } = require('../lib/setup')
+const { getSharedContext, dismissOnboarding, waitForWithTimeoutMessage, teardownSharedContext } = require('../lib/setup')
 const { seedTracks } = require('../lib/seed')
 const { resolveTestUserId } = require('../lib/test-user')
 
@@ -31,6 +31,7 @@ const ensurePlayIconVisible = async (page) => {
 }
 
 test({
+  teardown: teardownSharedContext,
   setup: async () => {
     const { page } = await getSharedContext()
     const userId = await resolveTestUserId()

--- a/packages/back/test/browser/pull-to-refresh.js
+++ b/packages/back/test/browser/pull-to-refresh.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai')
 const { test } = require('cascade-test')
-const { getSharedContext, dismissOnboarding, waitForWithTimeoutMessage } = require('../lib/setup')
+const { getSharedContext, dismissOnboarding, waitForWithTimeoutMessage, teardownSharedContext } = require('../lib/setup')
 const { seedTracks } = require('../lib/seed')
 const { resolveTestUserId } = require('../lib/test-user')
 
@@ -34,6 +34,7 @@ const dispatchTouch = async (page, type, clientY) =>
   )
 
 test({
+  teardown: teardownSharedContext,
   setup: async () => {
     const { page } = await getSharedContext()
     const userId = await resolveTestUserId()

--- a/packages/back/test/browser/search.js
+++ b/packages/back/test/browser/search.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai')
 const { test } = require('cascade-test')
-const { getSharedContext, dismissOnboarding, waitForWithTimeoutMessage } = require('../lib/setup')
+const { getSharedContext, dismissOnboarding, waitForWithTimeoutMessage, teardownSharedContext } = require('../lib/setup')
 const { seedTracks } = require('../lib/seed')
 const { resolveTestUserId } = require('../lib/test-user')
 
@@ -41,6 +41,7 @@ const clickFirstPreviewEntityLink = async (page, entityType) => {
 }
 
 test({
+  teardown: teardownSharedContext,
   setup: async () => {
     const { page } = await getSharedContext()
     const userId = await resolveTestUserId()

--- a/packages/back/test/browser/settings-slider.js
+++ b/packages/back/test/browser/settings-slider.js
@@ -1,10 +1,11 @@
 const { expect } = require('chai')
 const { test } = require('cascade-test')
-const { getSharedContext, dismissOnboarding, waitForWithTimeoutMessage } = require('../lib/setup')
+const { getSharedContext, dismissOnboarding, waitForWithTimeoutMessage, teardownSharedContext } = require('../lib/setup')
 
 const SLIDER_SELECTOR = 'input[type="range"][id^="weights-"]'
 
 test({
+  teardown: teardownSharedContext,
   setup: async () => {
     const { page } = await getSharedContext()
     await page.goto('/settings/sorting')

--- a/packages/back/test/browser/settings.js
+++ b/packages/back/test/browser/settings.js
@@ -1,11 +1,12 @@
 const { expect } = require('chai')
 const { test } = require('cascade-test')
-const { getSharedContext, dismissOnboarding, waitForWithTimeoutMessage } = require('../lib/setup')
+const { getSharedContext, dismissOnboarding, waitForWithTimeoutMessage, teardownSharedContext } = require('../lib/setup')
 const { seedTracks } = require('../lib/seed')
 const { seededTrackAssertions } = require('../lib/seed')
 const { resolveTestUserId } = require('../lib/test-user')
 
 test({
+  teardown: teardownSharedContext,
   setup: async () => {
     const { page } = await getSharedContext()
     const userId = await resolveTestUserId()

--- a/packages/back/test/lib/setup.js
+++ b/packages/back/test/lib/setup.js
@@ -238,6 +238,50 @@ const demoOverlay = () => {
   }
 }
 
+// Close the recording context and browser so Playwright flushes the video to
+// disk. Playwright only writes a recorded video when its context (or the owning
+// browser) closes — closing the browser also finalises the videos of every
+// context on it. Idempotent: each handle is captured and nulled before the
+// (async) close so a second call (or a concurrent beforeExit) can't double-close.
+const teardownSharedContext = async () => {
+  if (sharedBrowserContext) {
+    const context = sharedBrowserContext
+    sharedBrowserContext = null
+    await context.close().catch(() => {})
+  }
+  if (sharedBrowser) {
+    const browser = sharedBrowser
+    sharedBrowser = null
+    await browser.close().catch(() => {})
+  }
+  initPromise = null
+}
+
+// cascade-test ends every forked test process with `process.exit()` (see
+// `setTimeout(() => process.exit(exitCode), 0)` in its runner). Node does NOT
+// emit `beforeExit` for an explicit `process.exit()`, so the `beforeExit`
+// cleanup below never runs under the test runner — which is why demo recordings
+// came out as zero-byte files: Playwright created the video but the context was
+// never closed to flush it. When recording, defer the real exit until the
+// context/browser has closed (capped so a hung close can't wedge CI).
+if (isRecording) {
+  const realExit = process.exit.bind(process)
+  let flushing = false
+  process.exit = (code) => {
+    if (flushing) {
+      return realExit(code)
+    }
+    flushing = true
+    const finish = () => realExit(code)
+    const guard = setTimeout(finish, 10000)
+    teardownSharedContext().finally(() => {
+      clearTimeout(guard)
+      finish()
+    })
+    return undefined
+  }
+}
+
 const initialize = async () => {
   let baseURL, server
 
@@ -331,16 +375,11 @@ const initialize = async () => {
     process.on('exit', () => server.kill())
   }
 
-  // Finalize video recording (if active) before process exits.
-  process.on('beforeExit', async () => {
-    if (sharedBrowserContext) {
-      await sharedBrowserContext.close().catch(() => {})
-      sharedBrowserContext = null
-    }
-    if (sharedBrowser) {
-      await sharedBrowser.close().catch(() => {})
-      sharedBrowser = null
-    }
+  // Fallback for non-runner exits that do emit `beforeExit` (e.g. a plain
+  // `node` invocation). Under cascade-test this never fires — the wrapped
+  // `process.exit` above handles flushing the recording instead.
+  process.on('beforeExit', () => {
+    teardownSharedContext().catch(() => {})
   })
 
   return { server, browser: sharedBrowser, context: sharedBrowserContext, page }
@@ -354,6 +393,11 @@ module.exports.getSharedContext = () => {
 }
 
 module.exports.getBrowserContext = () => sharedBrowserContext
+
+// Exposed so a test suite's `teardown` can also flush the recording explicitly
+// (cascade-test awaits `teardown` before exiting); the wrapped `process.exit`
+// makes this optional, but it's available for callers that want it.
+module.exports.teardownSharedContext = teardownSharedContext
 
 module.exports.dismissOnboarding = dismissOnboarding
 module.exports.waitForWithTimeoutMessage = waitForWithTimeoutMessage


### PR DESCRIPTION
## Summary

- Playwright only flushes recorded videos when the recording context/browser closes, but `cascade-test` calls `process.exit()` directly, which skips Node's `beforeExit` event. This caused demo recordings to be zero-byte files.
- Wrap `process.exit()` when recording is active to defer the actual exit until the context/browser has closed (with a 10s timeout guard).
- Extract the teardown logic into a reusable `teardownSharedContext()` function and expose it for explicit calls from test suite teardown hooks.
- Add verification steps in CI workflows to catch regressions of the zero-byte-video bug.

## Test plan

- CI workflows now verify that recorded videos are non-empty before uploading artifacts, catching any future regressions of this issue.
- Existing test infrastructure will exercise the wrapped `process.exit()` path during demo recording runs.

## Demo recording

This block opts the PR into the `pr-demo-local.yml` workflow, which records the
named test in demo mode. It's here to prove the fix end-to-end: the uploaded
`demo-local-pr-377` artifact should now contain a non-empty `.webm`, and the new
"Verify recording is non-empty" step should pass.

```demo-test
test/browser/pull-to-refresh.js
```

https://claude.ai/code/session_01RLnGMvueTXt9g8ev2gr5Yg



## Summary by CodeRabbit

* **Chores**
  * Added validation in CI workflows to detect empty video recordings and fail builds when recordings are not captured properly
  * Enhanced test setup to properly flush recorded videos before process exit, reducing zero-byte video output issues



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced demo recording workflows with validation to prevent empty video outputs in CI/CD.
  * Improved test infrastructure with proper cleanup of shared browser resources during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->