### PR TITLE
Make track-preview embedding ANN index migration idempotent

### DIFF
--- a/packages/back/migrations/sqls/20260531215832-add-track-preview-embedding-ann-index-down.sql
+++ b/packages/back/migrations/sqls/20260531215832-add-track-preview-embedding-ann-index-down.sql
@@ -1,2 +1,2 @@
-DROP INDEX idx_store__track_preview_embedding_hnsw_cosine
+DROP INDEX IF EXISTS idx_store__track_preview_embedding_hnsw_cosine
 ;

--- a/packages/back/migrations/sqls/20260531215832-add-track-preview-embedding-ann-index-up.sql
+++ b/packages/back/migrations/sqls/20260531215832-add-track-preview-embedding-ann-index-up.sql
@@ -5,7 +5,14 @@
 -- operator class (vector_cosine_ops) used by <=>. A full (non-partial) index
 -- is used so the planner can always satisfy the ordering, even when the
 -- embedding_type filter is supplied as a bind parameter.
-CREATE INDEX idx_store__track_preview_embedding_hnsw_cosine
+--
+-- IF NOT EXISTS keeps the migration idempotent: an interrupted deploy can leave
+-- the index present in the database while the migrations row is never recorded
+-- (e.g. the build connection dropped after the index committed). Because this is
+-- a plain, transactional CREATE INDEX, any index that survives by this name is a
+-- complete, valid one, so re-running should be a no-op rather than a hard failure
+-- on the duplicate relation name.
+CREATE INDEX IF NOT EXISTS idx_store__track_preview_embedding_hnsw_cosine
   ON store__track_preview_embedding
   USING hnsw (store__track_preview_embedding vector_cosine_ops)
 ;


### PR DESCRIPTION
The deploy failed with 'duplicate key value violates unique constraint
pg_class_relname_nsp_index' because the HNSW index already existed in the
database while its migrations row was never recorded (an earlier deploy's
build connection dropped after the index committed). Use CREATE INDEX IF
NOT EXISTS / DROP INDEX IF EXISTS so re-running the migration is a no-op
rather than a hard failure on the duplicate relation name.

https://claude.ai/code/session_01L7W6twRinTk1suLkCUH5f7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment robustness to handle interrupted or re-run migrations gracefully without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->