### PR TITLE
Record Playwright trace alongside demo video and upload to artifacts

### DIFF
--- a/.github/scripts/publish-trace.sh
+++ b/.github/scripts/publish-trace.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Publish Playwright trace zip(s) to the gh-pages branch so they can be opened
+# one-click in https://trace.playwright.dev/?trace=<url> without downloading.
+#
+# Usage: publish-trace.sh <kind> <trace-dir>
+#   <kind>      local | preview (the subdirectory the traces land under)
+#   <trace-dir> directory holding the *.zip trace files
+#
+# Required env:
+#   GITHUB_TOKEN       token with contents:write on this repo
+#   GITHUB_REPOSITORY  owner/repo (provided by Actions)
+#   PR_NUMBER          pull request number
+#
+# Traces are written to traces/pr-<PR_NUMBER>/<kind>/ on the gh-pages branch.
+# Each PR/kind owns its own subdirectory, so concurrent runs do not overwrite
+# one another; pushes that race are retried after re-syncing to the remote tip.
+#
+# IMPORTANT: the preview trace MUST already be redacted (see redact-trace.js)
+# before calling this — the gh-pages branch is world-readable on a public repo.
+
+KIND="${1:?usage: publish-trace.sh <kind> <trace-dir>}"
+TRACE_DIR="${2:?usage: publish-trace.sh <kind> <trace-dir>}"
+
+: "${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${PR_NUMBER:?PR_NUMBER is required}"
+
+shopt -s nullglob
+zips=("$TRACE_DIR"/*.zip)
+shopt -u nullglob
+if [ ${#zips[@]} -eq 0 ]; then
+  echo "[publish-trace] No trace zips in ${TRACE_DIR}; nothing to publish."
+  exit 0
+fi
+
+dest_rel="traces/pr-${PR_NUMBER}/${KIND}"
+remote="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+git clone --quiet --depth 1 --branch gh-pages --single-branch "$remote" "$workdir" 2>/dev/null && have_branch=1 || have_branch=0
+
+if [ "$have_branch" = "0" ]; then
+  echo "[publish-trace] gh-pages branch not found — creating it."
+  rm -rf "$workdir"
+  mkdir -p "$workdir"
+  git -C "$workdir" init --quiet
+  git -C "$workdir" checkout --quiet -b gh-pages
+  git -C "$workdir" remote add origin "$remote"
+fi
+
+git -C "$workdir" config user.name "github-actions[bot]"
+git -C "$workdir" config user.email "github-actions[bot]@users.noreply.github.com"
+
+copy_files() {
+  rm -rf "${workdir:?}/${dest_rel}"
+  mkdir -p "${workdir}/${dest_rel}"
+  cp "${zips[@]}" "${workdir}/${dest_rel}/"
+}
+
+attempt=0
+max_attempts=5
+delay=2
+while :; do
+  attempt=$((attempt + 1))
+  copy_files
+  git -C "$workdir" add --all
+  if git -C "$workdir" diff --cached --quiet; then
+    echo "[publish-trace] No changes to publish."
+    break
+  fi
+  git -C "$workdir" commit --quiet -m "Publish ${KIND} demo trace for PR #${PR_NUMBER}"
+  if git -C "$workdir" push --quiet origin gh-pages; then
+    echo "[publish-trace] Published ${#zips[@]} trace(s) to ${dest_rel} on gh-pages."
+    break
+  fi
+  if [ "$attempt" -ge "$max_attempts" ]; then
+    echo "::error::Failed to push traces to gh-pages after ${max_attempts} attempts."
+    exit 1
+  fi
+  echo "[publish-trace] Push rejected (attempt ${attempt}/${max_attempts}) — re-syncing and retrying in ${delay}s."
+  sleep "$delay"
+  delay=$((delay * 2))
+  # Re-sync to the remote tip; our subdirectory is preserved on the next copy.
+  if [ "$have_branch" = "1" ] || git -C "$workdir" ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+    have_branch=1
+    git -C "$workdir" fetch --quiet origin gh-pages
+    git -C "$workdir" reset --quiet --hard origin/gh-pages
+  fi
+done

--- a/.github/workflows/pr-demo-local.yml
+++ b/.github/workflows/pr-demo-local.yml
@@ -27,7 +27,8 @@ jobs:
     container: node:22
 
     permissions:
-      contents: read
+      # write (not read) so the trace can be published to the gh-pages branch.
+      contents: write
       pull-requests: write
 
     services:
@@ -53,7 +54,8 @@ jobs:
           cache: 'yarn'
 
       - name: Preinstall system dependencies
-        run: apt-get update && apt-get install -y git postgresql-client
+        # zip/unzip are needed by redact-trace.js to rewrite the trace archive.
+        run: apt-get update && apt-get install -y git postgresql-client unzip zip
 
       # The PR body provides the test path inside a fenced demo-test block.
       - name: Extract test file from PR body
@@ -138,6 +140,22 @@ jobs:
           echo "Recorded traces:"
           find "$DIR" -type f -name '*.zip' -printf '%s\t%p\n'
 
+      # Scrub the session cookie from the trace before it leaves the runner.
+      # The local login uses fixture creds (no live secret), but redacting keeps
+      # behaviour uniform with the preview workflow and guards future changes.
+      - name: Redact trace
+        if: always()
+        run: node packages/back/test/lib/redact-trace.js "$GITHUB_WORKSPACE/demo-output"
+
+      # Publish the trace to gh-pages for one-click viewing. Requires GitHub
+      # Pages to be enabled (Settings → Pages → Deploy from a branch → gh-pages).
+      - name: Publish trace to Pages
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: bash .github/scripts/publish-trace.sh local "$GITHUB_WORKSPACE/demo-output"
+
       # Surface what landed in demo-output in the PR comment — handy when a
       # recording is empty/missing and the raw run logs aren't readily accessible.
       - name: Collect recording diagnostics
@@ -172,22 +190,43 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const fs = require('fs')
             const succeeded = '${{ job.status }}' === 'success'
             const icon = succeeded ? '✅' : '❌'
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
             const diag = process.env.DEMO_DIAG || '(no diagnostics captured)'
+            const prNumber = context.payload.pull_request.number
+            const owner = context.repo.owner.toLowerCase()
+            const repo = context.repo.repo
+            const dir = `${process.env.GITHUB_WORKSPACE}/demo-output`
+            // trace.playwright.dev fetches the trace from a public, CORS-enabled
+            // URL passed via ?trace=. gh-pages Pages URL is primary;
+            // raw.githubusercontent.com is the fallback (works pre-Pages-enable).
+            const viewer = (url) => `https://trace.playwright.dev/?trace=${encodeURIComponent(url)}`
+            const traceLines = []
+            try {
+              for (const file of fs.readdirSync(dir).filter((f) => f.endsWith('.zip')).sort()) {
+                const rel = `traces/pr-${prNumber}/local/${file}`
+                const pagesUrl = `https://${owner}.github.io/${repo}/${rel}`
+                const rawUrl = `https://raw.githubusercontent.com/${owner}/${repo}/gh-pages/${rel}`
+                traceLines.push(`- \`${file}\`: [open in trace viewer](${viewer(pagesUrl)}) · [fallback](${viewer(rawUrl)})`)
+              }
+            } catch (e) {}
+            const traceSection = traceLines.length
+              ? ['', 'Open the Playwright trace in your browser — no download needed:', ...traceLines,
+                 '', "_If \"open in trace viewer\" can't load it, the repo's GitHub Pages isn't enabled yet — use the `fallback` link, or download the artifact and run `npx playwright show-trace`._"]
+              : []
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
+              issue_number: prNumber,
               body: [
                 `${icon} **Demo (local) ${succeeded ? 'succeeded' : 'failed'}**`,
                 '',
                 `[View recording and run logs](${runUrl})`,
+                ...traceSection,
                 '',
-                succeeded
-                  ? 'Download the `demo-local-pr-${{ github.event.pull_request.number }}` artifact from the run page to watch the video (`.webm`) and open the Playwright trace(s) (`.zip`) with `npx playwright show-trace trace.zip` (or `trace-mobile.zip` if the test exercised the mobile context).'
-                  : 'Check the run logs for details.',
+                'Or download the `demo-local-pr-${{ github.event.pull_request.number }}` artifact to watch the video (`.webm`) and open the trace(s) with `npx playwright show-trace trace.zip` (or `trace-mobile.zip`).',
                 '',
                 '<details><summary>Recording diagnostics</summary>',
                 '',

--- a/.github/workflows/pr-demo-local.yml
+++ b/.github/workflows/pr-demo-local.yml
@@ -130,6 +130,13 @@ jobs:
           fi
           echo "Recorded videos:"
           find "$DIR" -type f -name '*.webm' -printf '%s\t%p\n'
+          if ! find "$DIR" -type f -name '*.zip' -size +0c | grep -q .; then
+            echo "::error::No non-empty Playwright trace was written in ${DIR} — tracing produced no output."
+            ls -la "$DIR" || true
+            exit 1
+          fi
+          echo "Recorded traces:"
+          find "$DIR" -type f -name '*.zip' -printf '%s\t%p\n'
 
       # Surface what landed in demo-output in the PR comment — handy when a
       # recording is empty/missing and the raw run logs aren't readily accessible.
@@ -144,10 +151,15 @@ jobs:
             echo ""
             echo "webm files and sizes:"
             find "$DIR" -type f -name '*.webm' -printf '%s bytes\t%p\n' 2>&1 || echo "(none)"
+            echo ""
+            echo "trace files and sizes:"
+            find "$DIR" -type f -name '*.zip' -printf '%s bytes\t%p\n' 2>&1 || echo "(none)"
             echo "DIAG_EOF"
           } >> "$GITHUB_ENV"
 
-      - name: Upload demo video
+      # Uploads the whole demo-output dir, so the recorded video (.webm) and the
+      # Playwright trace(s) (.zip) ship together in the same artifact.
+      - name: Upload demo video and trace
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -174,7 +186,7 @@ jobs:
                 `[View recording and run logs](${runUrl})`,
                 '',
                 succeeded
-                  ? 'Download the `demo-local-pr-${{ github.event.pull_request.number }}` artifact from the run page to watch the video.'
+                  ? 'Download the `demo-local-pr-${{ github.event.pull_request.number }}` artifact from the run page to watch the video (`.webm`) and open the Playwright trace (`.zip`) with `npx playwright show-trace trace.zip`.'
                   : 'Check the run logs for details.',
                 '',
                 '<details><summary>Recording diagnostics</summary>',

--- a/.github/workflows/pr-demo-local.yml
+++ b/.github/workflows/pr-demo-local.yml
@@ -186,7 +186,7 @@ jobs:
                 `[View recording and run logs](${runUrl})`,
                 '',
                 succeeded
-                  ? 'Download the `demo-local-pr-${{ github.event.pull_request.number }}` artifact from the run page to watch the video (`.webm`) and open the Playwright trace (`.zip`) with `npx playwright show-trace trace.zip`.'
+                  ? 'Download the `demo-local-pr-${{ github.event.pull_request.number }}` artifact from the run page to watch the video (`.webm`) and open the Playwright trace(s) (`.zip`) with `npx playwright show-trace trace.zip` (or `trace-mobile.zip` if the test exercised the mobile context).'
                   : 'Check the run logs for details.',
                 '',
                 '<details><summary>Recording diagnostics</summary>',

--- a/.github/workflows/pr-demo-preview.yml
+++ b/.github/workflows/pr-demo-preview.yml
@@ -178,7 +178,7 @@ jobs:
                 `[View recording and run logs](${runUrl})`,
                 '',
                 succeeded
-                  ? 'Download the `demo-video-pr-${{ github.event.pull_request.number }}` artifact from the run page to watch the video (`.webm`) and open the Playwright trace (`.zip`) with `npx playwright show-trace trace.zip`.'
+                  ? 'Download the `demo-video-pr-${{ github.event.pull_request.number }}` artifact from the run page to watch the video (`.webm`) and open the Playwright trace(s) (`.zip`) with `npx playwright show-trace trace.zip` (or `trace-mobile.zip` if the test exercised the mobile context).'
                   : 'Check the run logs for details.',
               ].join('\n'),
             })

--- a/.github/workflows/pr-demo-preview.yml
+++ b/.github/workflows/pr-demo-preview.yml
@@ -32,7 +32,8 @@ jobs:
     permissions:
       # Required to mint a GitHub Actions OIDC token for keyless login.
       id-token: write
-      contents: read
+      # write (not read) so the trace can be published to the gh-pages branch.
+      contents: write
       pull-requests: write
 
     steps:
@@ -148,6 +149,27 @@ jobs:
           echo "Recorded traces:"
           find "$DIR" -type f -name '*.zip' -printf '%s\t%p\n'
 
+      # ── 6b. Redact secrets from the trace ─────────────────────────────────
+      # The preview login authenticates with the live OIDC token and the trace
+      # carries the resulting session cookie on every request. Scrub both before
+      # the trace is uploaded as an artifact OR published to Pages. Runs even on
+      # test failure so a failing run's trace is still safe to inspect.
+      - name: Redact trace
+        if: always()
+        run: node packages/back/test/lib/redact-trace.js "${{ github.workspace }}/demo-output"
+        # OIDC_TOKEN is already in env from step 4 (used as a literal to scrub).
+
+      # ── 6c. Publish the redacted trace to gh-pages for one-click viewing ──
+      # Requires GitHub Pages to be enabled for this repo (Settings → Pages →
+      # Deploy from a branch → gh-pages → /). The published URL is then opened
+      # directly in https://trace.playwright.dev/ — no download needed.
+      - name: Publish trace to Pages
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: bash .github/scripts/publish-trace.sh preview "${{ github.workspace }}/demo-output"
+
       # ── 7. Upload the recorded video and trace ────────────────────────────
       # Uploads the whole demo-output dir, so the recorded video (.webm) and the
       # Playwright trace(s) (.zip) ship together in the same artifact.
@@ -165,20 +187,42 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const fs = require('fs')
             const succeeded = '${{ job.status }}' === 'success'
             const icon = succeeded ? '✅' : '❌'
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            const prNumber = context.payload.pull_request.number
+            const owner = context.repo.owner.toLowerCase()
+            const repo = context.repo.repo
+            const dir = `${process.env.GITHUB_WORKSPACE}/demo-output`
+            // trace.playwright.dev is a static client-side viewer: it fetches
+            // the trace from a public, CORS-enabled URL passed via ?trace=. The
+            // gh-pages Pages URL is the primary; raw.githubusercontent.com (also
+            // CORS-enabled) is a fallback that works even before Pages is enabled.
+            const viewer = (url) => `https://trace.playwright.dev/?trace=${encodeURIComponent(url)}`
+            const traceLines = []
+            try {
+              for (const file of fs.readdirSync(dir).filter((f) => f.endsWith('.zip')).sort()) {
+                const rel = `traces/pr-${prNumber}/preview/${file}`
+                const pagesUrl = `https://${owner}.github.io/${repo}/${rel}`
+                const rawUrl = `https://raw.githubusercontent.com/${owner}/${repo}/gh-pages/${rel}`
+                traceLines.push(`- \`${file}\`: [open in trace viewer](${viewer(pagesUrl)}) · [fallback](${viewer(rawUrl)})`)
+              }
+            } catch (e) {}
+            const traceSection = traceLines.length
+              ? ['', 'Open the Playwright trace in your browser — no download needed (secrets redacted):', ...traceLines,
+                 '', "_If \"open in trace viewer\" can't load it, the repo's GitHub Pages isn't enabled yet — use the `fallback` link, or download the artifact and run `npx playwright show-trace`._"]
+              : []
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
+              issue_number: prNumber,
               body: [
                 `${icon} **Demo test ${succeeded ? 'succeeded' : 'failed'}**`,
                 '',
                 `[View recording and run logs](${runUrl})`,
+                ...traceSection,
                 '',
-                succeeded
-                  ? 'Download the `demo-video-pr-${{ github.event.pull_request.number }}` artifact from the run page to watch the video (`.webm`) and open the Playwright trace(s) (`.zip`) with `npx playwright show-trace trace.zip` (or `trace-mobile.zip` if the test exercised the mobile context).'
-                  : 'Check the run logs for details.',
+                'Or download the `demo-video-pr-${{ github.event.pull_request.number }}` artifact to watch the video (`.webm`) and open the trace(s) with `npx playwright show-trace trace.zip` (or `trace-mobile.zip`).',
               ].join('\n'),
             })

--- a/.github/workflows/pr-demo-preview.yml
+++ b/.github/workflows/pr-demo-preview.yml
@@ -140,9 +140,18 @@ jobs:
           fi
           echo "Recorded videos:"
           find "$DIR" -type f -name '*.webm' -printf '%s\t%p\n'
+          if ! find "$DIR" -type f -name '*.zip' -size +0c | grep -q .; then
+            echo "::error::No non-empty Playwright trace was written in ${DIR} — tracing produced no output."
+            ls -la "$DIR" || true
+            exit 1
+          fi
+          echo "Recorded traces:"
+          find "$DIR" -type f -name '*.zip' -printf '%s\t%p\n'
 
-      # ── 7. Upload the recorded video ──────────────────────────────────────
-      - name: Upload demo video
+      # ── 7. Upload the recorded video and trace ────────────────────────────
+      # Uploads the whole demo-output dir, so the recorded video (.webm) and the
+      # Playwright trace(s) (.zip) ship together in the same artifact.
+      - name: Upload demo video and trace
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -169,7 +178,7 @@ jobs:
                 `[View recording and run logs](${runUrl})`,
                 '',
                 succeeded
-                  ? 'Download the `demo-video-pr-${{ github.event.pull_request.number }}` artifact from the run page to watch the video.'
+                  ? 'Download the `demo-video-pr-${{ github.event.pull_request.number }}` artifact from the run page to watch the video (`.webm`) and open the Playwright trace (`.zip`) with `npx playwright show-trace trace.zip`.'
                   : 'Check the run logs for details.',
               ].join('\n'),
             })

--- a/packages/back/test/lib/redact-trace.js
+++ b/packages/back/test/lib/redact-trace.js
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+'use strict'
+
+// Scrub secrets from Playwright trace zip(s) in place, so a trace can be
+// published for review without leaking credentials.
+//
+// Usage:
+//   node redact-trace.js <dir-or-zip> [<dir-or-zip> ...]
+//
+// A directory argument is expanded to every *.zip it contains (non-recursive).
+//
+// What gets redacted across EVERY entry of each trace zip:
+//   1. The literal OIDC_TOKEN value (from the OIDC_TOKEN env var), if set. The
+//      preview login no longer records the token (tracing starts after login,
+//      see setup.js), but this is belt-and-suspenders in case it surfaces in a
+//      redirect URL or response body.
+//   2. Any session cookie value — `connect.sid=<value>` in Cookie request
+//      headers and Set-Cookie response headers — regardless of value, so we do
+//      not need to know the server-issued id ahead of time.
+//
+// Trace zips contain newline-delimited JSON (*.trace / *.network / *.stacks)
+// plus binary resource blobs. We read every entry as latin1, which preserves
+// bytes 1:1, so the literal/regex replacements scrub ASCII secrets without
+// corrupting binary resources. unzip/zip CLIs do the (de)compression — both CI
+// runners provide them (ubuntu-latest natively; the node:22 container installs
+// them alongside git).
+
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const { execFileSync } = require('child_process')
+
+const REDACTED = 'REDACTED'
+// `connect.sid=` followed by the cookie value. The value stops at the first
+// delimiter: `;` (cookie/attribute separator), a quote (the header sits inside
+// a JSON string in the trace), whitespace, or a backslash (JSON escape). This
+// matches both `connect.sid=s%3A...` (URL-encoded) and bare forms, and leaves
+// the `connect.sid=` prefix in place so the trace still reads sensibly.
+const SESSION_COOKIE_RE = /connect\.sid=[^;"'\s\\]+/g
+
+const collectZips = (target) => {
+  let stat
+  try {
+    stat = fs.statSync(target)
+  } catch {
+    console.warn(`[redact-trace] Skipping missing path: ${target}`)
+    return []
+  }
+  if (stat.isDirectory()) {
+    return fs
+      .readdirSync(target)
+      .filter((name) => name.toLowerCase().endsWith('.zip'))
+      .map((name) => path.join(target, name))
+  }
+  return target.toLowerCase().endsWith('.zip') ? [target] : []
+}
+
+const walkFiles = (dir) => {
+  const out = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      out.push(...walkFiles(full))
+    } else if (entry.isFile()) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+const redactContent = (content, literals) => {
+  let next = content
+  for (const literal of literals) {
+    if (next.includes(literal)) {
+      next = next.split(literal).join(REDACTED)
+    }
+  }
+  next = next.replace(SESSION_COOKIE_RE, `connect.sid=${REDACTED}`)
+  return next
+}
+
+const redactZip = (zipPath, literals) => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-redact-'))
+  try {
+    execFileSync('unzip', ['-qq', '-o', zipPath, '-d', tmpDir])
+
+    let redactedFiles = 0
+    for (const file of walkFiles(tmpDir)) {
+      const original = fs.readFileSync(file, 'latin1')
+      const updated = redactContent(original, literals)
+      if (updated !== original) {
+        fs.writeFileSync(file, updated, 'latin1')
+        redactedFiles += 1
+      }
+    }
+
+    // Rebuild the archive from scratch: `zip` would otherwise merge into the
+    // existing file and keep the unredacted entries.
+    fs.rmSync(zipPath, { force: true })
+    execFileSync('zip', ['-q', '-r', '-X', path.resolve(zipPath), '.'], { cwd: tmpDir })
+    console.log(`[redact-trace] Redacted ${redactedFiles} entr${redactedFiles === 1 ? 'y' : 'ies'} in ${zipPath}`)
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  }
+}
+
+const main = () => {
+  const targets = process.argv.slice(2)
+  if (targets.length === 0) {
+    console.error('Usage: node redact-trace.js <dir-or-zip> [<dir-or-zip> ...]')
+    process.exit(1)
+  }
+
+  const literals = []
+  const oidcToken = process.env.OIDC_TOKEN
+  // Guard against redacting trivially short/empty values that would mangle the
+  // whole trace.
+  if (oidcToken && oidcToken.length >= 8) {
+    literals.push(oidcToken)
+  }
+
+  const zips = targets.flatMap(collectZips)
+  if (zips.length === 0) {
+    console.warn('[redact-trace] No trace zips found to redact.')
+    return
+  }
+
+  for (const zip of zips) {
+    redactZip(zip, literals)
+  }
+}
+
+main()

--- a/packages/back/test/lib/setup.js
+++ b/packages/back/test/lib/setup.js
@@ -9,6 +9,11 @@ let sharedBrowserContext = null
 let sharedBrowser = null
 let sharedBaseURL = null
 let mobilePromise = null
+// Contexts with an active Playwright trace, paired with the file the trace must
+// be written to. Unlike video (flushed when the context/browser closes), a
+// trace is only saved when `tracing.stop({ path })` is called explicitly, so we
+// track every traced context here and stop them all during teardown.
+let pendingTraces = []
 
 const BACKEND_ROOT = path.resolve(__dirname, '../..')
 const FRONTEND_ROOT = path.resolve(BACKEND_ROOT, '../front')
@@ -240,12 +245,38 @@ const demoOverlay = () => {
   }
 }
 
+// Start a Playwright trace on a context and remember where to write it. Called
+// only when recording (VIDEO_DIR set) so a demo run produces a trace alongside
+// its video. Screenshots + snapshots + sources give the full trace-viewer
+// timeline (DOM snapshots, network, console, and test source).
+const startTracing = async (context, tracePath) => {
+  await context.tracing.start({ screenshots: true, snapshots: true, sources: true })
+  pendingTraces.push({ context, path: tracePath })
+}
+
+// Stop every active trace, writing each to its file. Must run before the owning
+// context/browser closes, otherwise the trace is lost. Idempotent: the queue is
+// captured and cleared up front so a second call can't double-stop.
+const flushPendingTraces = async () => {
+  if (pendingTraces.length === 0) {
+    return
+  }
+  const traces = pendingTraces
+  pendingTraces = []
+  for (const { context, path: tracePath } of traces) {
+    await context.tracing.stop({ path: tracePath }).catch(() => {})
+  }
+}
+
 // Close the recording context and browser so Playwright flushes the video to
 // disk. Playwright only writes a recorded video when its context (or the owning
 // browser) closes — closing the browser also finalises the videos of every
 // context on it. Idempotent: each handle is captured and nulled before the
 // (async) close so a second call (or a concurrent beforeExit) can't double-close.
 const teardownSharedContext = async () => {
+  // Save traces before closing anything — stopping a trace on a closed context
+  // would throw and lose it.
+  await flushPendingTraces()
   if (sharedBrowserContext) {
     const context = sharedBrowserContext
     sharedBrowserContext = null
@@ -315,6 +346,10 @@ const initialize = async () => {
     contextOptions.recordVideo = { dir: videoDir, size: { width: 1280, height: 720 } }
   }
   sharedBrowserContext = await sharedBrowser.newContext(contextOptions)
+
+  if (videoDir) {
+    await startTracing(sharedBrowserContext, path.join(videoDir, 'trace.zip'))
+  }
 
   if (isRemotePreview || isRecording) {
     await sharedBrowserContext.addInitScript(demoOverlay)
@@ -409,6 +444,10 @@ const initializeMobile = async () => {
 
   const mobileContext = await sharedBrowser.newContext(contextOptions)
 
+  if (videoDir) {
+    await startTracing(mobileContext, path.join(videoDir, 'trace-mobile.zip'))
+  }
+
   if (isRemotePreview || isRecording) {
     await mobileContext.addInitScript(demoOverlay)
   }
@@ -433,6 +472,9 @@ const initializeMobile = async () => {
   const page = await mobileContext.newPage()
 
   process.on('beforeExit', async () => {
+    // Save any pending traces before closing — a trace can't be stopped on a
+    // closed context.
+    await flushPendingTraces()
     await mobileContext.close().catch(() => {})
   })
 

--- a/packages/back/test/lib/setup.js
+++ b/packages/back/test/lib/setup.js
@@ -264,7 +264,11 @@ const flushPendingTraces = async () => {
   const traces = pendingTraces
   pendingTraces = []
   for (const { context, path: tracePath } of traces) {
-    await context.tracing.stop({ path: tracePath }).catch(() => {})
+    await context.tracing.stop({ path: tracePath }).catch((error) => {
+      // Surface the cause: a swallowed failure leaves the trace missing/empty
+      // and the CI verify step would then fail with no hint as to why.
+      console.warn(`[browser-test] Failed to flush trace to ${tracePath}: ${error?.message ?? error}`)
+    })
   }
 }
 

--- a/packages/back/test/lib/setup.js
+++ b/packages/back/test/lib/setup.js
@@ -351,10 +351,6 @@ const initialize = async () => {
   }
   sharedBrowserContext = await sharedBrowser.newContext(contextOptions)
 
-  if (videoDir) {
-    await startTracing(sharedBrowserContext, path.join(videoDir, 'trace.zip'))
-  }
-
   if (isRemotePreview || isRecording) {
     await sharedBrowserContext.addInitScript(demoOverlay)
   }
@@ -404,6 +400,15 @@ const initialize = async () => {
     if (!sessionCookies.some(({ name }) => name === 'connect.sid')) {
       throw new Error('Login did not establish a session cookie')
     }
+  }
+
+  // Start tracing only AFTER login. The remote-preview login posts the live
+  // OIDC token as a request body; recording it would bake that secret into
+  // trace.zip (which we publish for review). Starting here keeps the token out
+  // of the trace entirely — the session cookie that every later request still
+  // carries is scrubbed separately by test/lib/redact-trace.js before upload.
+  if (videoDir) {
+    await startTracing(sharedBrowserContext, path.join(videoDir, 'trace.zip'))
   }
 
   await page.goto('/tracks/recent')


### PR DESCRIPTION
The demo-test (pr-demo-local) and demo-preview (pr-demo-preview) runs now
capture a Playwright trace in addition to the video whenever recording is
enabled (VIDEO_DIR set).

setup.js starts tracing on the shared (and mobile) context when recording,
and writes trace.zip / trace-mobile.zip into VIDEO_DIR during the same
teardown that flushes the video. Unlike video, a trace is only saved when
tracing.stop({ path }) is called explicitly, so traces are tracked and
flushed before any context/browser close.

The existing artifact upload already ships the whole demo-output dir, so the
trace travels with the video. Both workflows now verify the trace is
non-empty, surface it in diagnostics, and tell reviewers to open it with
`npx playwright show-trace trace.zip`.

## Demo runs (verifying trace capture)

The blocks below trigger the two demo workflows so the `trace.zip` artifact
can be confirmed.

Note: the demo-preview job is expected to report a red status because
`admin-radiator-preview.js` asserts on seeded chart data that the live
Railway preview does not contain — this is a pre-existing data/environment
issue, not a problem with the trace change. The trace is still produced and
uploaded in that run.

```demo-test
test/browser/admin-radiator-local.js
```

```demo-preview
test/browser/admin-radiator-preview.js
```

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to validate and report both demo videos and Playwright trace artifacts before uploading
  * Expanded PR comment messaging to guide reviewers on accessing recorded traces from demo artifacts
  * Enhanced test setup to automatically capture Playwright trace files alongside video recordings
