### PR TITLE
Add database indexes for track search sort columns

### DIFF
--- a/packages/back/migrations/20260603120000-add-track-search-sort-indexes.js
+++ b/packages/back/migrations/20260603120000-add-track-search-sort-indexes.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20260603120000-add-track-search-sort-indexes-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+
+      if (db.log.isSilent !== true) {
+        console.log('received data: ' + data)
+      }
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20260603120000-add-track-search-sort-indexes-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      if (db.log.isSilent !== true) {
+        console.log('received data: ' + data)
+      }
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/packages/back/migrations/sqls/20260603120000-add-track-search-sort-indexes-down.sql
+++ b/packages/back/migrations/sqls/20260603120000-add-track-search-sort-indexes-down.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS idx_store__track_store__track_released
+;
+
+DROP INDEX IF EXISTS idx_store__track_store__track_published
+;
+
+DROP INDEX IF EXISTS idx_track_track_added
+;

--- a/packages/back/migrations/sqls/20260603120000-add-track-search-sort-indexes-up.sql
+++ b/packages/back/migrations/sqls/20260603120000-add-track-search-sort-indexes-up.sql
@@ -1,0 +1,36 @@
+-- Sort-column indexes backing the track search in routes/shared/db/search.js.
+--
+-- searchForTracks() resolves a page of track ids with a join across the catalog
+-- followed by `ORDER BY <sort column> ... LIMIT <n>`. The sortable columns come
+-- from the aliasToColumn map in search.js:
+--   released  -> store__track.store__track_released   (default sort, -released)
+--   published -> store__track.store__track_published
+--   added     -> track.track_added                    (also used by the addedSince filter)
+-- None of these columns were indexed, so the page query degraded to a full scan
+-- + sort that grows with the catalog. DESC ordering matches the default
+-- `-released` sort and the descending sorts the UI requests; PostgreSQL can also
+-- scan a DESC btree backwards for the ASC case.
+--
+-- IF NOT EXISTS keeps the migration idempotent: an interrupted deploy can leave
+-- an index present in the database while the migrations row is never recorded
+-- (e.g. the build connection dropped after the index committed). Because these
+-- are plain, transactional CREATE INDEX statements, any index that survives by
+-- one of these names is a complete, valid one, so re-running is a no-op rather
+-- than a hard failure on the duplicate relation name.
+--
+-- Note: a non-CONCURRENT build takes a SHARE lock that blocks writes to the
+-- target table for the duration of the build (consistent with the rest of this
+-- migration set, e.g. the HNSW embedding index). On a large store__track this
+-- can be a noticeable window; build CONCURRENTLY out of band first if that
+-- write pause is unacceptable in production.
+CREATE INDEX IF NOT EXISTS idx_store__track_store__track_released
+  ON store__track (store__track_released DESC)
+;
+
+CREATE INDEX IF NOT EXISTS idx_store__track_store__track_published
+  ON store__track (store__track_published DESC)
+;
+
+CREATE INDEX IF NOT EXISTS idx_track_track_added
+  ON track (track_added DESC)
+;


### PR DESCRIPTION
## Summary

- Adds three descending indexes on the sort columns used by `searchForTracks()` in `routes/shared/db/search.js`: `store__track_released`, `store__track_published`, and `track_added`
- Resolves performance degradation in track search pagination queries that were falling back to full table scans as the catalog grows
- Uses `CREATE INDEX IF NOT EXISTS` for idempotency in case of interrupted deployments

## Test plan

No testing needed. This is a straightforward database schema migration that adds indexes to support existing query patterns. The indexes are created with `IF NOT EXISTS` to be safe for re-runs.

## Sentry

```sentry-also-resolves
```

https://claude.ai/code/session_01LWinnru17NEfdHwWzp26vH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Database optimizations implemented for track search and sorting operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->