### PR TITLE
Add purchased-cart follow suggestions with ignore to Settings

### DIFF
--- a/.github/workflows/pr-demo-local.yml
+++ b/.github/workflows/pr-demo-local.yml
@@ -108,7 +108,10 @@ jobs:
         env:
           DATABASE_URL: postgres://postgres:postgres@postgres/multi-store-player-test
           REACT_APP_ENV: ci
-          PW_SLOWMO: '600'
+          # Pace the recording slowly enough to follow, and hold on the final
+          # frame for a moment at the end so the closing state is reviewable.
+          PW_SLOWMO: '1200'
+          PW_END_IDLE_MS: '4000'
         run: |
           export VIDEO_DIR="$GITHUB_WORKSPACE/demo-output"
           TEST_FILE="${{ steps.demo.outputs.test_file }}"

--- a/.github/workflows/pr-demo-preview.yml
+++ b/.github/workflows/pr-demo-preview.yml
@@ -118,7 +118,11 @@ jobs:
           PREVIEW_URL: ${{ steps.preview.outputs.url }}
           VIDEO_DIR: ${{ github.workspace }}/demo-output
           # OIDC_TOKEN is already in env from step 4
-          # PW_SLOWMO defaults to 600ms when PREVIEW_URL is set (see setup.js)
+          # Pace the recording slowly enough to follow (overrides the 600ms
+          # default in setup.js), and hold on the final frame at the end so the
+          # closing state is reviewable.
+          PW_SLOWMO: '1200'
+          PW_END_IDLE_MS: '4000'
         run: |
           cd packages/back
           TEST_FILE="${{ steps.demo.outputs.test_file }}"

--- a/packages/back/migrations/20260607120000-add-follow-suggestion-ignores.js
+++ b/packages/back/migrations/20260607120000-add-follow-suggestion-ignores.js
@@ -1,0 +1,55 @@
+'use strict'
+
+var dbm
+var type
+var seed
+var fs = require('fs')
+var path = require('path')
+var Promise
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  var filePath = path.join(__dirname, 'sqls', '20260607120000-add-follow-suggestion-ignores-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      if (db.log.isSilent !== true) {
+        console.log('received data: ' + data)
+      }
+
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports.down = function (db) {
+  var filePath = path.join(__dirname, 'sqls', '20260607120000-add-follow-suggestion-ignores-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      if (db.log.isSilent !== true) {
+        console.log('received data: ' + data)
+      }
+
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports._meta = {
+  version: 1,
+}

--- a/packages/back/migrations/sqls/20260607120000-add-follow-suggestion-ignores-down.sql
+++ b/packages/back/migrations/sqls/20260607120000-add-follow-suggestion-ignores-down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS user__label_follow_suggestion_ignore;
+DROP TABLE IF EXISTS user__artist_follow_suggestion_ignore;

--- a/packages/back/migrations/sqls/20260607120000-add-follow-suggestion-ignores-up.sql
+++ b/packages/back/migrations/sqls/20260607120000-add-follow-suggestion-ignores-up.sql
@@ -1,0 +1,21 @@
+CREATE TABLE user__artist_follow_suggestion_ignore
+(
+    user__artist_follow_suggestion_ignore_id SERIAL PRIMARY KEY,
+    artist_id                                INTEGER NOT NULL REFERENCES artist (artist_id) ON DELETE CASCADE,
+    meta_account_user_id                     INTEGER NOT NULL REFERENCES meta_account (meta_account_user_id) ON DELETE CASCADE,
+    UNIQUE (artist_id, meta_account_user_id)
+);
+
+CREATE INDEX idx_user__artist_follow_suggestion_ignore_user
+    ON user__artist_follow_suggestion_ignore (meta_account_user_id);
+
+CREATE TABLE user__label_follow_suggestion_ignore
+(
+    user__label_follow_suggestion_ignore_id SERIAL PRIMARY KEY,
+    label_id                                INTEGER NOT NULL REFERENCES label (label_id) ON DELETE CASCADE,
+    meta_account_user_id                    INTEGER NOT NULL REFERENCES meta_account (meta_account_user_id) ON DELETE CASCADE,
+    UNIQUE (label_id, meta_account_user_id)
+);
+
+CREATE INDEX idx_user__label_follow_suggestion_ignore_user
+    ON user__label_follow_suggestion_ignore (meta_account_user_id);

--- a/packages/back/routes/users/api.js
+++ b/packages/back/routes/users/api.js
@@ -16,6 +16,7 @@ const {
   getUserLabelIgnores,
   getArtistFollowSuggestions,
   getLabelFollowSuggestions,
+  getFollowSuggestionImages,
   addArtistFollowSuggestionIgnore,
   addLabelFollowSuggestionIgnore,
   removeArtistFollowSuggestionIgnore,
@@ -347,6 +348,12 @@ router.get('/follows/suggestions', async ({ user: { id: authUserId }, query: { s
     getLabelFollowSuggestions(authUserId, stores),
   ])
   res.send({ artists, labels })
+})
+
+// Resolve cover images for suggestions lazily so the list renders immediately
+// and images backfill (entity artwork isn't stored, it comes live from stores).
+router.post('/follows/suggestions/images', async ({ body: { urls } }, res) => {
+  res.send(await getFollowSuggestionImages(urls))
 })
 
 // Dismiss a suggestion so it no longer appears, reducing noise in the list.

--- a/packages/back/routes/users/api.js
+++ b/packages/back/routes/users/api.js
@@ -14,6 +14,12 @@ const {
   getUserArtistIgnores,
   getUserArtistOnLabelIgnores,
   getUserLabelIgnores,
+  getArtistFollowSuggestions,
+  getLabelFollowSuggestions,
+  addArtistFollowSuggestionIgnore,
+  addLabelFollowSuggestionIgnore,
+  removeArtistFollowSuggestionIgnore,
+  removeLabelFollowSuggestionIgnore,
   removeArtistOnLabelIgnoreFromUser,
   removeLabelIgnoreFromUser,
   removeArtistIgnoreFromUser,
@@ -332,6 +338,39 @@ router.post('/follows/playlists', async ({ user: { id: userId }, body }, res) =>
   const sourceId = await insertSource({ operation: '/follows/playlists' })
   const addedPlaylists = await addPlaylistFollows(body, userId, sourceId)
   res.send(addedPlaylists)
+})
+
+// Follow suggestions derived from the tracks in the user's purchased cart.
+router.get('/follows/suggestions', async ({ user: { id: authUserId }, query: { store: stores } }, res) => {
+  const [artists, labels] = await Promise.all([
+    getArtistFollowSuggestions(authUserId, stores),
+    getLabelFollowSuggestions(authUserId, stores),
+  ])
+  res.send({ artists, labels })
+})
+
+// Dismiss a suggestion so it no longer appears, reducing noise in the list.
+router.post('/follows/suggestions/ignores', async ({ user: { id: authUserId }, body: { type, id } }, res) => {
+  if (type === 'artist') {
+    await addArtistFollowSuggestionIgnore(authUserId, id)
+  } else if (type === 'label') {
+    await addLabelFollowSuggestionIgnore(authUserId, id)
+  } else {
+    return res.status(400).send({ error: `Unknown suggestion type: ${type}` })
+  }
+  res.status(204).send()
+})
+
+// Undo a dismissal (also used to keep demo seeding re-run safe).
+router.delete('/follows/suggestions/ignores/:type/:id', async ({ user: { id: authUserId }, params: { type, id } }, res) => {
+  if (type === 'artist') {
+    await removeArtistFollowSuggestionIgnore(authUserId, id)
+  } else if (type === 'label') {
+    await removeLabelFollowSuggestionIgnore(authUserId, id)
+  } else {
+    return res.status(400).send({ error: `Unknown suggestion type: ${type}` })
+  }
+  res.status(204).send()
 })
 
 router.put('/follows/:type/:id', async ({ user: { id: userId }, params: { id, type }, body: { starred } }, res) => {

--- a/packages/back/routes/users/db.js
+++ b/packages/back/routes/users/db.js
@@ -420,6 +420,7 @@ FROM (
     ORDER BY purchased_artist_counts.artist_id, store_name
 ) suggestions
 ORDER BY count DESC, name
+LIMIT 24
 `,
   )
 }
@@ -474,6 +475,7 @@ FROM (
     ORDER BY purchased_label_counts.label_id, store_name
 ) suggestions
 ORDER BY count DESC, name
+LIMIT 24
 `,
   )
 }

--- a/packages/back/routes/users/db.js
+++ b/packages/back/routes/users/db.js
@@ -364,6 +364,162 @@ ORDER BY 1, store_name
   )
 }
 
+// Suggest artists to follow based on the tracks the user has purchased (the
+// tracks in their purchased cart). An artist is suggested when it authored at
+// least one purchased track, the user does not already follow it on any store,
+// and the user has not dismissed the suggestion. The count is the number of
+// distinct purchased tracks by the artist; a representative store URL is picked
+// so the suggestion can be followed with the existing follow-by-url flow.
+module.exports.queryArtistFollowSuggestions = async (userId, stores = undefined) => {
+  return pg.queryRowsAsync(
+    // language=PostgreSQL
+    sql`-- queryArtistFollowSuggestions
+WITH purchased_artist_counts AS (
+    SELECT artist_id
+         , COUNT(DISTINCT track_id) AS count
+    FROM cart
+             NATURAL JOIN track__cart
+             NATURAL JOIN track__artist
+    WHERE meta_account_user_id = ${userId}
+      AND cart_is_purchased
+      AND track__artist_role = 'author'
+    GROUP BY artist_id
+)
+SELECT id
+     , name
+     , url
+     , "storeName"
+     , count
+FROM (
+    SELECT DISTINCT ON (purchased_artist_counts.artist_id)
+           purchased_artist_counts.artist_id AS id
+         , artist_name                       AS name
+         , store__artist_url                 AS url
+         , store_name                        AS "storeName"
+         , purchased_artist_counts.count :: INT AS count
+    FROM purchased_artist_counts
+             NATURAL JOIN artist
+             NATURAL JOIN store__artist
+             NATURAL JOIN store
+    WHERE store__artist_url IS NOT NULL
+      AND (${stores}::TEXT IS NULL OR LOWER(store_name) = ANY (${stores}))
+      AND NOT EXISTS (
+            SELECT 1
+            FROM store__artist_watch
+                     NATURAL JOIN store__artist_watch__user
+                     NATURAL JOIN store__artist AS followed_store__artist
+            WHERE followed_store__artist.artist_id = purchased_artist_counts.artist_id
+              AND meta_account_user_id = ${userId}
+        )
+      AND NOT EXISTS (
+            SELECT 1
+            FROM user__artist_follow_suggestion_ignore
+            WHERE artist_id = purchased_artist_counts.artist_id
+              AND meta_account_user_id = ${userId}
+        )
+    ORDER BY purchased_artist_counts.artist_id, store_name
+) suggestions
+ORDER BY count DESC, name
+`,
+  )
+}
+
+// Label equivalent of queryArtistFollowSuggestions.
+module.exports.queryLabelFollowSuggestions = async (userId, stores = undefined) => {
+  return pg.queryRowsAsync(
+    // language=PostgreSQL
+    sql`-- queryLabelFollowSuggestions
+WITH purchased_label_counts AS (
+    SELECT label_id
+         , COUNT(DISTINCT track_id) AS count
+    FROM cart
+             NATURAL JOIN track__cart
+             NATURAL JOIN track__label
+    WHERE meta_account_user_id = ${userId}
+      AND cart_is_purchased
+    GROUP BY label_id
+)
+SELECT id
+     , name
+     , url
+     , "storeName"
+     , count
+FROM (
+    SELECT DISTINCT ON (purchased_label_counts.label_id)
+           purchased_label_counts.label_id AS id
+         , label_name                      AS name
+         , store__label_url                AS url
+         , store_name                      AS "storeName"
+         , purchased_label_counts.count :: INT AS count
+    FROM purchased_label_counts
+             NATURAL JOIN label
+             NATURAL JOIN store__label
+             NATURAL JOIN store
+    WHERE store__label_url IS NOT NULL
+      AND (${stores}::TEXT IS NULL OR LOWER(store_name) = ANY (${stores}))
+      AND NOT EXISTS (
+            SELECT 1
+            FROM store__label_watch
+                     NATURAL JOIN store__label_watch__user
+                     NATURAL JOIN store__label AS followed_store__label
+            WHERE followed_store__label.label_id = purchased_label_counts.label_id
+              AND meta_account_user_id = ${userId}
+        )
+      AND NOT EXISTS (
+            SELECT 1
+            FROM user__label_follow_suggestion_ignore
+            WHERE label_id = purchased_label_counts.label_id
+              AND meta_account_user_id = ${userId}
+        )
+    ORDER BY purchased_label_counts.label_id, store_name
+) suggestions
+ORDER BY count DESC, name
+`,
+  )
+}
+
+module.exports.addArtistFollowSuggestionIgnore = async (userId, artistId) => {
+  return pg.queryAsync(
+    // language=PostgreSQL
+    sql`-- addArtistFollowSuggestionIgnore
+INSERT INTO user__artist_follow_suggestion_ignore (meta_account_user_id, artist_id)
+VALUES (${userId}, ${artistId})
+ON CONFLICT (artist_id, meta_account_user_id) DO NOTHING
+`,
+  )
+}
+
+module.exports.addLabelFollowSuggestionIgnore = async (userId, labelId) => {
+  return pg.queryAsync(
+    // language=PostgreSQL
+    sql`-- addLabelFollowSuggestionIgnore
+INSERT INTO user__label_follow_suggestion_ignore (meta_account_user_id, label_id)
+VALUES (${userId}, ${labelId})
+ON CONFLICT (label_id, meta_account_user_id) DO NOTHING
+`,
+  )
+}
+
+module.exports.deleteArtistFollowSuggestionIgnore = async (userId, artistId) => {
+  return pg.queryAsync(
+    // language=PostgreSQL
+    sql`-- deleteArtistFollowSuggestionIgnore
+DELETE FROM user__artist_follow_suggestion_ignore
+WHERE meta_account_user_id = ${userId} AND artist_id = ${artistId}
+`,
+  )
+}
+
+module.exports.deleteLabelFollowSuggestionIgnore = async (userId, labelId) => {
+  return pg.queryAsync(
+    // language=PostgreSQL
+    sql`-- deleteLabelFollowSuggestionIgnore
+DELETE FROM user__label_follow_suggestion_ignore
+WHERE meta_account_user_id = ${userId} AND label_id = ${labelId}
+`,
+  )
+}
+
 module.exports.queryUserPlaylistFollows = async (userId, stores = undefined) => {
   return pg.queryRowsAsync(
     // language=PostgreSQL

--- a/packages/back/routes/users/logic.js
+++ b/packages/back/routes/users/logic.js
@@ -30,6 +30,12 @@ const {
   queryUserArtistOnLabelIgnores,
   queryUserLabelIgnores,
   queryUserArtistIgnores,
+  queryArtistFollowSuggestions,
+  queryLabelFollowSuggestions,
+  addArtistFollowSuggestionIgnore,
+  addLabelFollowSuggestionIgnore,
+  deleteArtistFollowSuggestionIgnore,
+  deleteLabelFollowSuggestionIgnore,
   queryUserTracks,
   deleteArtistWatchesFromUser,
   deleteArtistWatchFromUser,
@@ -68,6 +74,13 @@ module.exports.getUserPlaylistFollows = queryUserPlaylistFollows
 module.exports.getUserArtistOnLabelIgnores = queryUserArtistOnLabelIgnores
 module.exports.getUserLabelIgnores = queryUserLabelIgnores
 module.exports.getUserArtistIgnores = queryUserArtistIgnores
+
+module.exports.getArtistFollowSuggestions = queryArtistFollowSuggestions
+module.exports.getLabelFollowSuggestions = queryLabelFollowSuggestions
+module.exports.addArtistFollowSuggestionIgnore = addArtistFollowSuggestionIgnore
+module.exports.addLabelFollowSuggestionIgnore = addLabelFollowSuggestionIgnore
+module.exports.removeArtistFollowSuggestionIgnore = deleteArtistFollowSuggestionIgnore
+module.exports.removeLabelFollowSuggestionIgnore = deleteLabelFollowSuggestionIgnore
 
 module.exports.removeArtistOnLabelIgnoreFromUser = deleteArtistOnLabelIgnoreFromUser
 module.exports.removeLabelIgnoreFromUser = deleteLabelIgnoreFromUser

--- a/packages/back/routes/users/logic.js
+++ b/packages/back/routes/users/logic.js
@@ -82,6 +82,39 @@ module.exports.addLabelFollowSuggestionIgnore = addLabelFollowSuggestionIgnore
 module.exports.removeArtistFollowSuggestionIgnore = deleteArtistFollowSuggestionIgnore
 module.exports.removeLabelFollowSuggestionIgnore = deleteLabelFollowSuggestionIgnore
 
+// Resolve cover images for follow suggestions on demand. We don't persist entity
+// artwork, so images are fetched live from the originating store (the same source
+// the follow-search results use). This is best-effort: any failure (store
+// unreachable, rate limited, parse error) yields a null image rather than failing
+// the request, and each lookup is time-boxed so a slow store can't hang the page.
+const SUGGESTION_IMAGE_TIMEOUT_MS = 8000
+const withTimeout = (promise, ms) =>
+  Promise.race([
+    promise,
+    new Promise((_, reject) => setTimeout(() => reject(new Error('Suggestion image lookup timed out')), ms)),
+  ])
+
+module.exports.getFollowSuggestionImages = async (urls) => {
+  const uniqueUrls = [...new Set((urls ?? []).filter((url) => typeof url === 'string' && url.length > 0))]
+  return BPromise.map(
+    uniqueUrls,
+    async (url) => {
+      try {
+        const details = await getStoreDetailsFromUrl(url)
+        const storeModule =
+          storeModules[details.storeName] || storeModules[details.storeName?.toLowerCase()]
+        if (!storeModule) return { url, img: null }
+        const [resolved] = await withTimeout(storeModule.logic.getFollowDetails(details), SUGGESTION_IMAGE_TIMEOUT_MS)
+        return { url, img: resolved?.img ?? null }
+      } catch (e) {
+        logger.warn(`Failed to resolve suggestion image for ${url}`, e)
+        return { url, img: null }
+      }
+    },
+    { concurrency: 6 },
+  )
+}
+
 module.exports.removeArtistOnLabelIgnoreFromUser = deleteArtistOnLabelIgnoreFromUser
 module.exports.removeLabelIgnoreFromUser = deleteLabelIgnoreFromUser
 module.exports.removeArtistIgnoreFromUser = deleteArtistIgnoreFromUser

--- a/packages/back/test/browser/follow-suggestions-local.js
+++ b/packages/back/test/browser/follow-suggestions-local.js
@@ -1,0 +1,20 @@
+// demo-test entry: purchased-cart follow suggestions on the Settings page.
+// Seeds purchased tracks through the public API (works locally and on preview),
+// so this file is identical to follow-suggestions-preview.js apart from this
+// comment — all behaviour lives in the shared steps/seed modules.
+
+const { test } = require('cascade-test')
+const { getSharedContext, teardownSharedContext } = require('../lib/setup')
+const { seedPurchasedViaApi } = require('../lib/follow-suggestions-seed')
+const { gotoFollowSuggestions, assertSuggestionsRenderAndIgnore } = require('../lib/follow-suggestions-steps')
+
+test({
+  teardown: teardownSharedContext,
+  setup: async () => {
+    const { page } = await getSharedContext()
+    await seedPurchasedViaApi(page)
+    await gotoFollowSuggestions(page)
+    return { page, timeout: 30000 }
+  },
+  'purchased-cart follow suggestions render and can be ignored': assertSuggestionsRenderAndIgnore,
+})

--- a/packages/back/test/browser/follow-suggestions-preview.js
+++ b/packages/back/test/browser/follow-suggestions-preview.js
@@ -1,0 +1,21 @@
+// demo-preview entry: purchased-cart follow suggestions on the Settings page.
+// Seeds purchased tracks through the public API only (no DB access), so it runs
+// unchanged against the remote Railway preview. Identical to
+// follow-suggestions-local.js apart from this comment — all behaviour lives in
+// the shared steps/seed modules.
+
+const { test } = require('cascade-test')
+const { getSharedContext, teardownSharedContext } = require('../lib/setup')
+const { seedPurchasedViaApi } = require('../lib/follow-suggestions-seed')
+const { gotoFollowSuggestions, assertSuggestionsRenderAndIgnore } = require('../lib/follow-suggestions-steps')
+
+test({
+  teardown: teardownSharedContext,
+  setup: async () => {
+    const { page } = await getSharedContext()
+    await seedPurchasedViaApi(page)
+    await gotoFollowSuggestions(page)
+    return { page, timeout: 30000 }
+  },
+  'purchased-cart follow suggestions render and can be ignored': assertSuggestionsRenderAndIgnore,
+})

--- a/packages/back/test/lib/follow-suggestions-seed.js
+++ b/packages/back/test/lib/follow-suggestions-seed.js
@@ -1,0 +1,69 @@
+// Seeding for the follow-suggestions demo tests.
+//
+// Follow suggestions are derived from the artists and labels behind the tracks
+// in the user's *purchased* cart. The real ingestion path for purchased tracks
+// is `POST /api/me/purchased` (the same endpoint the Chrome extension hits when
+// a purchase is detected), so we seed through it. Driving it via a browser-side
+// fetch means the request carries the logged-in session cookie and works
+// identically against the local backend and the remote Railway preview — no DB
+// access required, so the local and preview demo tests share this code.
+
+const { beatportTracksTransform } = require('../../../browser-extension/src/js/transforms/beatport')
+const { storeUrl: beatportUrl } = require('../../routes/stores/beatport/logic')
+
+const fixtures = [
+  require('../fixtures/noisia_concussion_beatport.json'),
+  require('../fixtures/noisia_purpose_beatport.json'),
+  require('../fixtures/noisia_purpose_remix_beatport.json'),
+  require('../fixtures/beatport_operator_track_pageprops.json'),
+  require('../fixtures/beatport_dub_power_track_pageprops.json'),
+  require('../fixtures/noisia_block_control_beatport.json'),
+]
+
+// The extension stamps each purchased track with the time it was bought; the
+// purchased-cart ingestion requires it (track__cart_added is NOT NULL), so we
+// add a fixed timestamp here rather than leaving it undefined.
+const PURCHASED_AT = '2024-01-01T00:00:00.000Z'
+const purchasedTracks = fixtures
+  .flatMap((fixture) => beatportTracksTransform(fixture))
+  .map((track) => ({ ...track, purchased: PURCHASED_AT }))
+
+const fetchViaBrowser = (page, path, { method = 'GET', body, headers } = {}) =>
+  page.evaluate(
+    async ({ path, method, body, headers }) => {
+      const res = await fetch(path, {
+        method,
+        credentials: 'same-origin',
+        headers: { ...(body ? { 'Content-Type': 'application/json' } : {}), ...(headers || {}) },
+        body: body ? JSON.stringify(body) : undefined,
+      })
+      const text = await res.text()
+      return { status: res.status, text }
+    },
+    { path, method, body, headers },
+  )
+
+module.exports.fetchViaBrowser = fetchViaBrowser
+module.exports.purchasedTrackCount = purchasedTracks.length
+
+// Idempotent: the purchased-cart insert does ON CONFLICT DO NOTHING, so running
+// this twice against the persistent preview is a no-op.
+module.exports.seedPurchasedViaApi = async (page) => {
+  const res = await fetchViaBrowser(page, '/api/me/purchased', {
+    method: 'POST',
+    body: purchasedTracks,
+    headers: { 'x-multi-store-player-store': beatportUrl },
+  })
+  if (res.status < 200 || res.status >= 300) {
+    throw new Error(`Seeding purchased tracks failed: HTTP ${res.status} — ${res.text}`)
+  }
+}
+
+// Undo a dismissal so the preview keeps a full set of suggestions for the next
+// re-run (the demo dismisses one suggestion, then restores it here).
+module.exports.restoreSuggestionViaApi = async (page, type, id) => {
+  const res = await fetchViaBrowser(page, `/api/me/follows/suggestions/ignores/${type}/${id}`, { method: 'DELETE' })
+  if (res.status < 200 || res.status >= 300) {
+    throw new Error(`Restoring suggestion failed: HTTP ${res.status} — ${res.text}`)
+  }
+}

--- a/packages/back/test/lib/follow-suggestions-steps.js
+++ b/packages/back/test/lib/follow-suggestions-steps.js
@@ -1,0 +1,58 @@
+// Shared browser steps and assertions for the follow-suggestions demo tests.
+// Imported verbatim by both the -local and -preview entry files so the only
+// difference between the two is how the purchased tracks are seeded.
+
+const { expect } = require('chai')
+const { waitForWithTimeoutMessage, dismissOnboarding } = require('./setup')
+const { restoreSuggestionViaApi } = require('./follow-suggestions-seed')
+
+const SUGGESTION = '[data-test="follow-suggestion"]'
+
+const gotoFollowSuggestions = async (page) => {
+  await page.goto('/settings/following')
+  await waitForWithTimeoutMessage(
+    () => page.waitForSelector('.settings-container', { timeout: 15000 }),
+    'Render the settings container before checking follow suggestions.',
+  )
+  await dismissOnboarding(page)
+  await waitForWithTimeoutMessage(
+    () => page.waitForSelector('[data-test="follow-suggestions"]', { timeout: 15000 }),
+    'Render the follow-suggestions section seeded from the purchased cart.',
+  )
+}
+
+// The suggestions list renders the artists/labels behind purchased tracks, each
+// with a Follow and an Ignore control; dismissing one removes it from the list.
+const assertSuggestionsRenderAndIgnore = async ({ page }) => {
+  await page.waitForSelector(SUGGESTION, { timeout: 15000 })
+
+  const countBefore = await page.locator(SUGGESTION).count()
+  expect(countBefore, 'at least one follow suggestion from purchased tracks').to.be.greaterThan(0)
+
+  // Every suggestion offers both a Follow and an Ignore control.
+  expect(await page.locator(`${SUGGESTION} [data-test="follow-suggestion-follow"]`).count()).to.equal(countBefore)
+  expect(await page.locator(`${SUGGESTION} [data-test="follow-suggestion-ignore"]`).count()).to.equal(countBefore)
+
+  const first = page.locator(SUGGESTION).first()
+  const type = await first.getAttribute('data-test-suggestion-type')
+  const id = await first.getAttribute('data-test-suggestion-id')
+  const name = await first.getAttribute('data-test-suggestion-name')
+  expect(name, 'dismissed suggestion has a name').to.be.a('string').and.not.empty
+
+  await first.locator('[data-test="follow-suggestion-ignore"]').click()
+
+  // The dismissed suggestion disappears from the list.
+  await waitForWithTimeoutMessage(
+    () =>
+      page.waitForSelector(`${SUGGESTION}[data-test-suggestion-name="${name}"]`, { state: 'detached', timeout: 10000 }),
+    `Remove the dismissed suggestion "${name}" from the list after clicking ignore.`,
+  )
+  const countAfter = await page.locator(SUGGESTION).count()
+  expect(countAfter, 'dismissing a suggestion removes exactly one entry').to.equal(countBefore - 1)
+
+  // Keep the persistent preview re-run safe by undoing the dismissal we just
+  // made, so the next run still sees a full set of suggestions.
+  await restoreSuggestionViaApi(page, type, id)
+}
+
+module.exports = { gotoFollowSuggestions, assertSuggestionsRenderAndIgnore }

--- a/packages/back/test/lib/setup.js
+++ b/packages/back/test/lib/setup.js
@@ -20,6 +20,13 @@ const isRemotePreview = Boolean(process.env.PREVIEW_URL)
 // give remote-preview runs: slow-mo pacing and the cursor/click/keyboard
 // overlay, so a locally recorded video reads as a demo rather than a raw test.
 const isRecording = Boolean(process.env.VIDEO_DIR)
+// Optional trailing idle (ms) held on the final frame before the recording is
+// flushed, so the closing state is easy to review. Set by the demo workflows
+// via PW_END_IDLE_MS; ignored outside recording so normal CI isn't slowed.
+const endIdleMs = (() => {
+  const value = Number(process.env.PW_END_IDLE_MS)
+  return Number.isFinite(value) && value > 0 ? value : 0
+})()
 
 const getLatestMtimeMs = async (targetPath) => {
   let stats
@@ -249,6 +256,11 @@ const teardownSharedContext = async () => {
   if (sharedBrowserContext) {
     const context = sharedBrowserContext
     sharedBrowserContext = null
+    // Linger on the final frame so the closing state is reviewable before
+    // Playwright stops recording on context close (recording runs only).
+    if (isRecording && endIdleMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, endIdleMs))
+    }
     await context.close().catch(() => {})
   }
   if (sharedBrowser) {
@@ -275,7 +287,9 @@ if (isRecording) {
     }
     flushing = true
     const finish = () => realExit(code)
-    const guard = setTimeout(finish, 10000)
+    // Allow for the trailing idle on top of the close budget so the recording
+    // has time to flush before the hard exit.
+    const guard = setTimeout(finish, 10000 + endIdleMs)
     teardownSharedContext().finally(() => {
       clearTimeout(guard)
       finish()

--- a/packages/front/src/FollowItemButton.js
+++ b/packages/front/src/FollowItemButton.js
@@ -23,7 +23,22 @@ class FollowItemButton extends Component {
           title={'Check details from store'}
           style={{ position: 'relative', height: 100, width: 100, display: 'block', margin: 'auto' }}
         >
-          <img src={img} style={{ height: '100%', width: '100%', objectFit: 'cover' }} />
+          {img ? (
+            <img src={img} style={{ height: '100%', width: '100%', objectFit: 'cover' }} />
+          ) : (
+            <span
+              className="follow-item-placeholder"
+              style={{
+                height: '100%',
+                width: '100%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <span aria-hidden="true" className={`store-icon store-icon-${storeName}`} />
+            </span>
+          )}
           <FontAwesomeIcon icon="external-link-alt" style={{ position: 'absolute', right: 5, bottom: 5 }} />
         </a>
         <div

--- a/packages/front/src/Settings.css
+++ b/packages/front/src/Settings.css
@@ -48,3 +48,25 @@
   outline-offset: 2px;
   border-radius: 2px;
 }
+
+.follow-suggestions {
+  margin-bottom: 1.5em;
+}
+
+.follow-suggestion-list .pill-button-contents {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+}
+
+.follow-suggestion-count {
+  display: inline-block;
+  min-width: 1.4em;
+  padding: 0 0.4em;
+  border-radius: 999px;
+  background-color: rgba(255, 255, 255, 0.25);
+  font-size: 80%;
+  line-height: 1.5;
+  text-align: center;
+  vertical-align: middle;
+}

--- a/packages/front/src/Settings.css
+++ b/packages/front/src/Settings.css
@@ -52,21 +52,3 @@
 .follow-suggestions {
   margin-bottom: 1.5em;
 }
-
-.follow-suggestion-list .pill-button-contents {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4em;
-}
-
-.follow-suggestion-count {
-  display: inline-block;
-  min-width: 1.4em;
-  padding: 0 0.4em;
-  border-radius: 999px;
-  background-color: rgba(255, 255, 255, 0.25);
-  font-size: 80%;
-  line-height: 1.5;
-  text-align: center;
-  vertical-align: middle;
-}

--- a/packages/front/src/Settings.css
+++ b/packages/front/src/Settings.css
@@ -52,3 +52,54 @@
 .follow-suggestions {
   margin-bottom: 1.5em;
 }
+
+.follow-suggestion-item {
+  position: relative;
+  display: inline-block;
+  vertical-align: top;
+}
+
+.follow-suggestion-count {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  min-width: 1.4em;
+  padding: 0 0.4em;
+  border-radius: 999px;
+  background-color: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  font-size: 80%;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.follow-suggestion-ignore-button {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background-color: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  cursor: pointer;
+}
+
+.follow-suggestion-ignore-button:hover:not(:disabled) {
+  background-color: rgba(0, 0, 0, 0.85);
+}
+
+.follow-suggestion-ignore-button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.follow-item-placeholder {
+  background-color: rgba(255, 255, 255, 0.08);
+  font-size: 200%;
+}

--- a/packages/front/src/Settings.js
+++ b/packages/front/src/Settings.js
@@ -498,7 +498,7 @@ class Settings extends Component {
         <h5>
           {label} ({suggestions.length})
         </h5>
-        <ul className="no-style-list follow-list follow-suggestion-list">
+        <ul className="no-style-list follow-list">
           {suggestions.map(({ id, name, url, storeName, count }) => {
             const busy = this.state.updatingSuggestion === `${type}-${id}`
             return (
@@ -511,24 +511,18 @@ class Settings extends Component {
               >
                 <span className="button pill pill-button">
                   <span className="pill-button-contents">
-                    <a href={url} target="_blank" rel="noopener noreferrer" title="Check details from store">
-                      <span aria-hidden="true" className={`store-icon store-icon-${storeName.toLowerCase()}`} /> {name}
-                    </a>
-                    <span className="follow-suggestion-count" title={`${count} purchased track(s)`}>
+                    <span aria-hidden="true" className={`store-icon store-icon-${storeName.toLowerCase()}`} /> {name}{' '}
+                    <span className="follow-results-count" title={`${count} purchased track(s)`}>
                       {count}
-                    </span>
-                    <SpinnerButton
-                      size="small"
-                      className="button button-push_button-small button-push_button-primary"
-                      loading={busy}
+                    </span>{' '}
+                    <button
                       disabled={this.state.updatingSuggestion !== null}
-                      icon="plus"
                       title={`Follow ${name}`}
                       data-test="follow-suggestion-follow"
                       onClick={() => this.onFollowSuggestionClick(type, { id, name, url })}
                     >
-                      Follow
-                    </SpinnerButton>
+                      {busy ? <Spinner size="small" /> : <FontAwesomeIcon icon="plus" />}
+                    </button>{' '}
                     <button
                       disabled={this.state.updatingSuggestion !== null}
                       title={`Ignore suggestion for ${name}`}
@@ -536,7 +530,18 @@ class Settings extends Component {
                       onClick={() => this.onIgnoreSuggestionClick(type, id)}
                     >
                       <FontAwesomeIcon icon="times-circle" />
-                    </button>
+                    </button>{' '}
+                    {url && (
+                      <a
+                        href={url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={(e) => e.stopPropagation()}
+                        title="Check details from store"
+                      >
+                        <FontAwesomeIcon icon="external-link-alt" />
+                      </a>
+                    )}
                   </span>
                 </span>
               </li>

--- a/packages/front/src/Settings.js
+++ b/packages/front/src/Settings.js
@@ -213,6 +213,33 @@ class Settings extends Component {
       path: `/me/follows/suggestions`,
     })
     this.setState({ followSuggestions })
+    // Backfill cover images without blocking the list render.
+    this.enrichSuggestionImages(followSuggestions)
+  }
+
+  async enrichSuggestionImages({ artists = [], labels = [] }) {
+    const urls = [...artists, ...labels].map(({ url }) => url).filter(Boolean)
+    if (urls.length === 0) {
+      return
+    }
+    try {
+      const images = await requestJSONwithCredentials({
+        path: `/me/follows/suggestions/images`,
+        method: 'POST',
+        body: { urls },
+      })
+      const imgByUrl = new Map(images.filter(({ img }) => img).map(({ url, img }) => [url, img]))
+      const merge = (items) => (items ?? []).map((s) => (imgByUrl.has(s.url) ? { ...s, img: imgByUrl.get(s.url) } : s))
+      this.setState((prev) => ({
+        followSuggestions: {
+          ...prev.followSuggestions,
+          artists: merge(prev.followSuggestions.artists),
+          labels: merge(prev.followSuggestions.labels),
+        },
+      }))
+    } catch (e) {
+      console.error('Enriching suggestion images failed', e)
+    }
   }
 
   async onFollowSuggestionClick(type, { id, name, url }) {
@@ -499,51 +526,44 @@ class Settings extends Component {
           {label} ({suggestions.length})
         </h5>
         <ul className="no-style-list follow-list">
-          {suggestions.map(({ id, name, url, storeName, count }) => {
+          {suggestions.map(({ id, name, url, storeName, count, img }) => {
             const busy = this.state.updatingSuggestion === `${type}-${id}`
             return (
               <li
                 key={`${type}-${id}`}
+                className="follow-suggestion-item"
                 data-test="follow-suggestion"
                 data-test-suggestion-type={type}
                 data-test-suggestion-id={id}
                 data-test-suggestion-name={name}
               >
-                <span className="button pill pill-button">
-                  <span className="pill-button-contents">
-                    <span aria-hidden="true" className={`store-icon store-icon-${storeName.toLowerCase()}`} /> {name}{' '}
-                    <span className="follow-results-count" title={`${count} purchased track(s)`}>
-                      {count}
-                    </span>{' '}
-                    <button
-                      disabled={this.state.updatingSuggestion !== null}
-                      title={`Follow ${name}`}
-                      data-test="follow-suggestion-follow"
-                      onClick={() => this.onFollowSuggestionClick(type, { id, name, url })}
-                    >
-                      {busy ? <Spinner size="small" /> : <FontAwesomeIcon icon="plus" />}
-                    </button>{' '}
-                    <button
-                      disabled={this.state.updatingSuggestion !== null}
-                      title={`Ignore suggestion for ${name}`}
-                      data-test="follow-suggestion-ignore"
-                      onClick={() => this.onIgnoreSuggestionClick(type, id)}
-                    >
-                      <FontAwesomeIcon icon="times-circle" />
-                    </button>{' '}
-                    {url && (
-                      <a
-                        href={url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        onClick={(e) => e.stopPropagation()}
-                        title="Check details from store"
-                      >
-                        <FontAwesomeIcon icon="external-link-alt" />
-                      </a>
-                    )}
-                  </span>
+                <FollowItemButton
+                  id={id}
+                  name={name}
+                  storeName={storeName.toLowerCase()}
+                  type={type}
+                  url={url}
+                  img={img}
+                  loading={busy}
+                  disabled={this.state.updatingSuggestion !== null}
+                  onClick={() => this.onFollowSuggestionClick(type, { id, name, url })}
+                  data-test="follow-suggestion-follow"
+                />
+                <span className="follow-suggestion-count" title={`${count} purchased track(s)`}>
+                  {count}
                 </span>
+                <button
+                  className="follow-suggestion-ignore-button"
+                  disabled={this.state.updatingSuggestion !== null}
+                  title={`Ignore suggestion for ${name}`}
+                  data-test="follow-suggestion-ignore"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    this.onIgnoreSuggestionClick(type, id)
+                  }}
+                >
+                  <FontAwesomeIcon icon="times-circle" />
+                </button>
               </li>
             )
           })}

--- a/packages/front/src/Settings.js
+++ b/packages/front/src/Settings.js
@@ -101,6 +101,8 @@ class Settings extends Component {
       artistFollows: [],
       labelFollows: [],
       playlistFollows: [],
+      followSuggestions: { artists: [], labels: [] },
+      updatingSuggestion: null,
       artistOnLabelIgnores: [],
       artistIgnores: [],
       labelIgnores: [],
@@ -166,6 +168,7 @@ class Settings extends Component {
     try {
       await Promise.all([
         this.updateFollows(),
+        this.updateFollowSuggestions(),
         this.updateIgnores(),
         this.updateAuthorizations(),
         this.updateAudioSamples(),
@@ -203,6 +206,54 @@ class Settings extends Component {
       path: `/me/follows/playlists`,
     })
     this.setState({ playlistFollows })
+  }
+
+  async updateFollowSuggestions() {
+    const followSuggestions = await requestJSONwithCredentials({
+      path: `/me/follows/suggestions`,
+    })
+    this.setState({ followSuggestions })
+  }
+
+  async onFollowSuggestionClick(type, { id, name, url }) {
+    this.setState({ updatingSuggestion: `${type}-${id}` })
+    try {
+      await this.onFollowItemClick(url, name, type)
+      // Drop the now-followed suggestion and refresh from the server so the
+      // counts and remaining suggestions stay in sync.
+      this.removeSuggestionFromState(type, id)
+      await this.updateFollowSuggestions()
+    } catch (e) {
+      console.error('Following suggestion failed', e)
+    } finally {
+      this.setState({ updatingSuggestion: null })
+    }
+  }
+
+  async onIgnoreSuggestionClick(type, id) {
+    this.setState({ updatingSuggestion: `${type}-${id}` })
+    try {
+      await requestWithCredentials({
+        path: `/me/follows/suggestions/ignores`,
+        method: 'POST',
+        body: { type, id },
+      })
+      this.removeSuggestionFromState(type, id)
+    } catch (e) {
+      console.error('Ignoring suggestion failed', e)
+    } finally {
+      this.setState({ updatingSuggestion: null })
+    }
+  }
+
+  removeSuggestionFromState(type, id) {
+    const key = type === 'artist' ? 'artists' : 'labels'
+    this.setState((prev) => ({
+      followSuggestions: {
+        ...prev.followSuggestions,
+        [key]: (prev.followSuggestions[key] ?? []).filter((s) => s.id !== id),
+      },
+    }))
   }
 
   async updateIgnores() {
@@ -437,6 +488,80 @@ class Settings extends Component {
           </React.Fragment>
         ))}
       </>
+    )
+  }
+
+  renderSuggestionList(type, suggestions) {
+    const label = type === 'artist' ? 'Artists' : 'Labels'
+    return (
+      <>
+        <h5>
+          {label} ({suggestions.length})
+        </h5>
+        <ul className="no-style-list follow-list follow-suggestion-list">
+          {suggestions.map(({ id, name, url, storeName, count }) => {
+            const busy = this.state.updatingSuggestion === `${type}-${id}`
+            return (
+              <li
+                key={`${type}-${id}`}
+                data-test="follow-suggestion"
+                data-test-suggestion-type={type}
+                data-test-suggestion-id={id}
+                data-test-suggestion-name={name}
+              >
+                <span className="button pill pill-button">
+                  <span className="pill-button-contents">
+                    <a href={url} target="_blank" rel="noopener noreferrer" title="Check details from store">
+                      <span aria-hidden="true" className={`store-icon store-icon-${storeName.toLowerCase()}`} /> {name}
+                    </a>
+                    <span className="follow-suggestion-count" title={`${count} purchased track(s)`}>
+                      {count}
+                    </span>
+                    <SpinnerButton
+                      size="small"
+                      className="button button-push_button-small button-push_button-primary"
+                      loading={busy}
+                      disabled={this.state.updatingSuggestion !== null}
+                      icon="plus"
+                      title={`Follow ${name}`}
+                      data-test="follow-suggestion-follow"
+                      onClick={() => this.onFollowSuggestionClick(type, { id, name, url })}
+                    >
+                      Follow
+                    </SpinnerButton>
+                    <button
+                      disabled={this.state.updatingSuggestion !== null}
+                      title={`Ignore suggestion for ${name}`}
+                      data-test="follow-suggestion-ignore"
+                      onClick={() => this.onIgnoreSuggestionClick(type, id)}
+                    >
+                      <FontAwesomeIcon icon="times-circle" />
+                    </button>
+                  </span>
+                </span>
+              </li>
+            )
+          })}
+        </ul>
+      </>
+    )
+  }
+
+  renderFollowSuggestions() {
+    const { artists = [], labels = [] } = this.state.followSuggestions ?? {}
+    if (artists.length === 0 && labels.length === 0) {
+      return null
+    }
+    return (
+      <div className="follow-suggestions" data-test="follow-suggestions">
+        <h4>Suggestions from your purchases</h4>
+        <p style={{ fontSize: '90%', marginTop: 0 }}>
+          Artists and labels behind the tracks in your purchased cart that you are not following yet. Follow the ones
+          you like, or ignore a suggestion to remove it from this list.
+        </p>
+        {artists.length > 0 && this.renderSuggestionList('artist', artists)}
+        {labels.length > 0 && this.renderSuggestionList('label', labels)}
+      </div>
     )
   }
 
@@ -850,6 +975,7 @@ class Settings extends Component {
                   </div>
                 )}
               </label>
+              {this.renderFollowSuggestions()}
               <h4>Followed</h4>
               <div
                 className="select-button select-button--container state-select-button--container noselect"


### PR DESCRIPTION
## What & why

Adds a **follow suggestions** list to the **Settings → Following** page, derived from the tracks in the user's **purchased cart**. The idea: the artists and labels behind what you've actually bought are strong follow candidates, but you may not have followed them yet.

Each suggestion shows:
- the artist/label name + store icon (links to the store page),
- a count badge of how many purchased tracks back the suggestion,
- a **Follow** button (reuses the existing follow-by-URL flow), and
- an **Ignore** button so the user can dismiss a suggestion and **reduce noise in the list**.

Suggestions exclude anything the user already follows (on any store) or has previously dismissed, and are ordered by purchase count (most-purchased first). The section only renders when there is at least one suggestion, so users without purchases see no change.

## Implementation

**Backend**
- Migration adds `user__artist_follow_suggestion_ignore` and `user__label_follow_suggestion_ignore` (per DB naming conventions; FK columns named after the parent PK so the existing `NATURAL JOIN` chains keep composing).
- `queryArtistFollowSuggestions` / `queryLabelFollowSuggestions` aggregate the purchased cart's tracks → artists/labels, filtering out already-followed and dismissed entries, picking a followable per-store URL.
- Endpoints: `GET /me/follows/suggestions`, `POST /me/follows/suggestions/ignores`, `DELETE /me/follows/suggestions/ignores/:type/:id` (the delete/un-ignore also keeps the persistent preview re-run safe).

**Front-end**
- `Settings.js`: fetches suggestions on mount, renders the section, wires Follow + Ignore with optimistic list removal.

## Tests / demo

Paired demo tests share all steps and seed purchased tracks through the public API only (works identically local + preview, no DB access). Verified locally: both demo tests pass, the existing `settings.js` browser suite still passes, and a non-empty `.webm` is recorded.

```demo-test
test/browser/follow-suggestions-local.js
```

```demo-preview
test/browser/follow-suggestions-preview.js
```

https://claude.ai/code/session_017bBvso7EQ19H5BKtma7REG

---
_Generated by [Claude Code](https://claude.ai/code/session_017bBvso7EQ19H5BKtma7REG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Personalized artist and label follow suggestions based on your purchase history
  * Dismiss (ignore) suggestions and restore dismissed suggestions later
  * Follow suggestions directly from Settings with in-progress state feedback

* **UI / Style**
  * Suggestions section added to Following settings with artwork, count badges, and ignore buttons
  * Image placeholders shown when artwork is unavailable

* **Tests**
  * Browser tests and seeding helpers for the follow-suggestions workflow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->