### PR TITLE
Fix mobile cart popup positioning behind player bar

### DIFF
--- a/packages/back/test/browser/cart-popup-mobile-local.js
+++ b/packages/back/test/browser/cart-popup-mobile-local.js
@@ -1,0 +1,26 @@
+// Local demo (demo-test workflow): runs against a backend in the same runner.
+// The mobile add-to-cart popup only needs some tracks to exist; seedTracks
+// branches on PREVIEW_URL (direct DB here) so the seeding line is shared with
+// the preview test.
+const { test } = require('cascade-test')
+const { getMobileContext, teardownSharedContext } = require('../lib/setup')
+const { seedTracks } = require('../lib/seed')
+const { resolveTestUserId } = require('../lib/test-user')
+const {
+  gotoTracksAndOpenCartPopup,
+  assertCartPopupAnchoredBottomAndOnTop,
+} = require('../lib/cart-popup-mobile-steps')
+
+test({
+  teardown: teardownSharedContext,
+  setup: async () => {
+    const { page } = await getMobileContext()
+    const userId = await resolveTestUserId()
+    await seedTracks({ userIds: [userId] })
+    await gotoTracksAndOpenCartPopup(page)
+    return { page, timeout: 30000 }
+  },
+
+  'add-to-cart popup is anchored bottom-middle, on top, with a full-screen overlay':
+    assertCartPopupAnchoredBottomAndOnTop,
+})

--- a/packages/back/test/browser/cart-popup-mobile-preview.js
+++ b/packages/back/test/browser/cart-popup-mobile-preview.js
@@ -1,0 +1,26 @@
+// Preview demo (demo-preview workflow): runs against the deployed Railway PR
+// preview with no direct DB access. The mobile add-to-cart popup only needs some
+// tracks to exist; seedTracks branches on PREVIEW_URL (POST /api/me/tracks here)
+// so the seeding line is shared with the local test.
+const { test } = require('cascade-test')
+const { getMobileContext, teardownSharedContext } = require('../lib/setup')
+const { seedTracks } = require('../lib/seed')
+const { resolveTestUserId } = require('../lib/test-user')
+const {
+  gotoTracksAndOpenCartPopup,
+  assertCartPopupAnchoredBottomAndOnTop,
+} = require('../lib/cart-popup-mobile-steps')
+
+test({
+  teardown: teardownSharedContext,
+  setup: async () => {
+    const { page } = await getMobileContext()
+    const userId = await resolveTestUserId()
+    await seedTracks({ userIds: [userId] })
+    await gotoTracksAndOpenCartPopup(page)
+    return { page, timeout: 30000 }
+  },
+
+  'add-to-cart popup is anchored bottom-middle, on top, with a full-screen overlay':
+    assertCartPopupAnchoredBottomAndOnTop,
+})

--- a/packages/back/test/lib/cart-popup-mobile-steps.js
+++ b/packages/back/test/lib/cart-popup-mobile-steps.js
@@ -1,0 +1,117 @@
+const { expect } = require('chai')
+const { dismissOnboarding, waitForWithTimeoutMessage } = require('./setup')
+
+// Shared browser interactions/assertions for the mobile add-to-cart popup demo.
+// Both the local (demo-test) and preview (demo-preview) entry files import these
+// verbatim; only the way tracks are seeded differs (and that is itself shared
+// via seedTracks, which branches on PREVIEW_URL).
+
+const TRACK_SELECTOR = '.tracks-table .track'
+// The add-to-cart control in a track row is the only split DropDownButton there:
+// its left half adds to the default cart, its right half (the caret) opens the
+// popup we are exercising.
+const CART_CARET_SELECTOR = `${TRACK_SELECTOR} .table-cell-button-row .button-drop_down-right`
+// The popup content only exists in the DOM while the popup is open (on mobile it
+// is click-, not hover-driven), so this selector doubles as an "is open" check.
+const CART_POPUP_SELECTOR = '.cart-popup.popup_content'
+
+const gotoTracksAndOpenCartPopup = async (page) => {
+  await page.goto('/tracks/recent')
+  await waitForWithTimeoutMessage(
+    () => page.waitForSelector(TRACK_SELECTOR, { timeout: 15000 }),
+    'Load the tracks table with at least one seeded row before opening the cart popup.',
+  )
+  await dismissOnboarding(page)
+
+  await waitForWithTimeoutMessage(
+    () => page.waitForSelector(CART_CARET_SELECTOR, { state: 'visible', timeout: 10000 }),
+    'The first track row should expose an add-to-cart dropdown caret on mobile.',
+  )
+  // Tap the caret on the first track row to open the add-to-cart popup.
+  await page.click(CART_CARET_SELECTOR)
+
+  await waitForWithTimeoutMessage(
+    () => page.waitForSelector(CART_POPUP_SELECTOR, { state: 'visible', timeout: 10000 }),
+    'Tapping the cart caret should open the add-to-cart popup.',
+  )
+}
+
+// The regression this guards against: after the swipe-to-mark-heard change each
+// track <tr> became `position: relative`, which trapped the `position: absolute`
+// popup at the bottom of its row and confined the dark overlay to that row, so
+// the popup slipped behind the player. The popup must instead be pinned to the
+// bottom-middle of the viewport, on top of everything, with a full-screen
+// backdrop behind it.
+const assertCartPopupAnchoredBottomAndOnTop = async ({ page }) => {
+  const metrics = await page.evaluate((popupSelector) => {
+    const content = document.querySelector(popupSelector)
+    if (!content) throw new Error('cart popup content not found')
+    const container = content.closest('.popup_container')
+    const overlay = container && container.nextElementSibling
+    if (!overlay || !overlay.classList.contains('popup_overlay')) {
+      throw new Error('cart popup overlay not found next to the open popup container')
+    }
+
+    const vw = window.innerWidth
+    const vh = window.innerHeight
+    const c = content.getBoundingClientRect()
+    const o = overlay.getBoundingClientRect()
+    const contentStyle = getComputedStyle(content)
+    const overlayStyle = getComputedStyle(overlay)
+
+    // A point near the top of the screen, over the player/table the popup used
+    // to hide behind. With the fix the full-screen overlay covers it on top.
+    const topEl = document.elementFromPoint(Math.round(vw / 2), 24)
+    const overlayOnTopAtTop = topEl === overlay || overlay.contains(topEl)
+
+    // The centre of the popup should hit the popup (or its content), not
+    // anything painted above it.
+    const cx = Math.round((c.left + c.right) / 2)
+    const cy = Math.round((c.top + c.bottom) / 2)
+    const centreEl = document.elementFromPoint(cx, cy)
+    const popupOnTopAtCentre = centreEl === content || content.contains(centreEl)
+
+    return {
+      vw,
+      vh,
+      content: { left: c.left, right: c.right, bottom: c.bottom },
+      overlay: { left: o.left, top: o.top, width: o.width, height: o.height },
+      contentPosition: contentStyle.position,
+      overlayPosition: overlayStyle.position,
+      overlayDisplay: overlayStyle.display,
+      overlayOnTopAtTop,
+      popupOnTopAtCentre,
+    }
+  }, CART_POPUP_SELECTOR)
+
+  // Anchored to the viewport (not the track row) via position: fixed …
+  expect(metrics.contentPosition, 'popup should be position: fixed').to.equal('fixed')
+  expect(metrics.overlayPosition, 'overlay should be position: fixed').to.equal('fixed')
+
+  // … pinned to the bottom of the screen …
+  expect(metrics.content.bottom, 'popup should sit at the bottom of the viewport').to.be.closeTo(metrics.vh, 2)
+
+  // … and horizontally centred (equal gutters either side).
+  const leftGutter = metrics.content.left
+  const rightGutter = metrics.vw - metrics.content.right
+  expect(leftGutter, 'popup should have a left gutter').to.be.greaterThan(0)
+  expect(Math.abs(leftGutter - rightGutter), 'popup should be horizontally centred').to.be.lessThan(4)
+
+  // The dark backdrop covers the whole viewport (previously only the row).
+  expect(metrics.overlay.left, 'overlay should start at the left edge').to.be.closeTo(0, 1)
+  expect(metrics.overlay.top, 'overlay should start at the top edge').to.be.closeTo(0, 1)
+  expect(metrics.overlay.width, 'overlay should span the viewport width').to.be.closeTo(metrics.vw, 2)
+  expect(metrics.overlay.height, 'overlay should span the viewport height').to.be.closeTo(metrics.vh, 2)
+  expect(metrics.overlayDisplay, 'overlay should be visible').to.not.equal('none')
+
+  // The popup and overlay render above the player bar / table content.
+  expect(metrics.overlayOnTopAtTop, 'overlay should cover the area above the table').to.equal(true)
+  expect(metrics.popupOnTopAtCentre, 'popup should render on top at its centre').to.equal(true)
+}
+
+module.exports = {
+  TRACK_SELECTOR,
+  CART_POPUP_SELECTOR,
+  gotoTracksAndOpenCartPopup,
+  assertCartPopupAnchoredBottomAndOnTop,
+}

--- a/packages/back/test/lib/cart-popup-mobile-steps.js
+++ b/packages/back/test/lib/cart-popup-mobile-steps.js
@@ -16,11 +16,20 @@ const CART_CARET_SELECTOR = `${TRACK_SELECTOR} .table-cell-button-row .button-dr
 const CART_POPUP_SELECTOR = '.cart-popup.popup_content'
 
 const gotoTracksAndOpenCartPopup = async (page) => {
+  // The remote preview is shared and redeploys on every push, so it can be cold
+  // or mid-restart when this runs — the seeded tracks then take longer than a
+  // warm backend to render. Wait generously and reload once before giving up.
+  // Locally the rows appear immediately, so this adds no real delay there.
   await page.goto('/tracks/recent')
-  await waitForWithTimeoutMessage(
-    () => page.waitForSelector(TRACK_SELECTOR, { timeout: 15000 }),
-    'Load the tracks table with at least one seeded row before opening the cart popup.',
-  )
+  try {
+    await page.waitForSelector(TRACK_SELECTOR, { timeout: 20000 })
+  } catch {
+    await page.goto('/tracks/recent')
+    await waitForWithTimeoutMessage(
+      () => page.waitForSelector(TRACK_SELECTOR, { timeout: 20000 }),
+      'Load the tracks table with at least one seeded row before opening the cart popup.',
+    )
+  }
   await dismissOnboarding(page)
 
   await waitForWithTimeoutMessage(

--- a/packages/front/src/Popup.css
+++ b/packages/front/src/Popup.css
@@ -48,11 +48,18 @@
    * trap an `position: absolute` popup at the bottom of its row. `fixed` pins it
    * to the bottom-middle of the screen and the z-index lifts it above the
    * player bar.
+   *
+   * Centre via `left: 50%` + `translateX(-50%)` rather than symmetric
+   * `left`/`right`: popups such as the cart popup cap their width with
+   * `max-width`, and with `left`, `right` and `width` all constrained the
+   * browser drops `right`, pinning the popup off-centre against the left
+   * gutter. Constraining width instead keeps it centred at any width.
    */
   .popup_content {
     position: fixed;
-    left: 2rem;
-    right: 2rem;
+    left: 50%;
+    transform: translateX(-50%);
+    width: calc(100% - 4rem);
     bottom: 0;
     background: black;
     border-bottom-left-radius: 0;

--- a/packages/front/src/Popup.css
+++ b/packages/front/src/Popup.css
@@ -42,7 +42,15 @@
 }
 
 @media (max-width: 590px) {
+  /*
+   * Anchor the popup to the viewport (not the row). The swipe-to-mark-heard
+   * feature gives each track row `position: relative`, which would otherwise
+   * trap an `position: absolute` popup at the bottom of its row. `fixed` pins it
+   * to the bottom-middle of the screen and the z-index lifts it above the
+   * player bar.
+   */
   .popup_content {
+    position: fixed;
     left: 2rem;
     right: 2rem;
     bottom: 0;
@@ -51,6 +59,13 @@
     border-bottom-right-radius: 0;
     flex-direction: column;
     align-content: flex-end;
+    z-index: 1001;
+  }
+
+  /* Full-screen dark backdrop pinned to the viewport, behind the popup. */
+  .popup_overlay {
+    position: fixed;
+    z-index: 1000;
   }
 
   .mobile .popup_content {


### PR DESCRIPTION
## Summary

- Fixed mobile add-to-cart popup being trapped behind the player bar by anchoring it to the viewport with `position: fixed` instead of inheriting the track row's `position: relative` (introduced by the swipe-to-mark-heard change)
- Added a full-screen dark overlay (`z-index: 1000`) behind the popup (`z-index: 1001`) so both render above the player
- Added paired demo browser tests (local + preview) that share all steps/assertions and only differ in seeding

## Test plan

The added demo tests verify the fix:
- `demo-test`: runs locally against a seeded database
- `demo-preview`: runs against the deployed preview with API-seeded tracks

Both tests assert that:
- Popup is `position: fixed` and anchored to the viewport bottom
- Popup is horizontally centered with equal gutters
- The full-screen overlay covers the entire viewport and renders on top of the player/table
- The popup renders above the overlay at its center point

```demo-test
test/browser/cart-popup-mobile-local.js
```

```demo-preview
test/browser/cart-popup-mobile-preview.js
```

https://claude.ai/code/session_01VSZgDyAaNNCfrqcGjTGWWx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mobile add-to-cart popup positioning—now properly anchored to the viewport bottom with correct overlay stacking, ensuring the dark overlay displays beneath the popup.

* **Tests**
  * Added mobile end-to-end tests validating add-to-cart popup layout anchoring and visual stacking behavior on small screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->