### PR TITLE
fix(auth): preserve extension PKCE state across Passport 0.7 session regen

### DIFF
--- a/packages/back/routes/auth.js
+++ b/packages/back/routes/auth.js
@@ -362,7 +362,30 @@ const createAuthRouter = ({
     if (!isExtensionFlowConfigured) {
       return res.status(503).json({ error: 'Extension login is not configured on this backend' })
     }
-    return passport.authenticate('openidconnect', { state: { returnToExtension: true } })(req, res, next)
+    const extensionId = req.session?.extensionId
+    const extensionCodeChallenge = req.session?.extensionCodeChallenge
+    const extensionCodeChallengeMethod = req.session?.extensionCodeChallengeMethod
+    const extensionState = req.session?.extensionState
+    const extensionRedirectUri = req.session?.extensionRedirectUri
+    if (!isExtensionIdAllowed(extensionId)) {
+      return res.status(400).json({ error: 'Session missing or invalid extensionId' })
+    }
+    if (!extensionCodeChallenge || extensionCodeChallengeMethod !== 'S256' || !extensionState) {
+      return res.status(400).json({ error: 'Session missing PKCE parameters' })
+    }
+    if (!isAllowedExtensionRedirectUri(extensionRedirectUri)) {
+      return res.status(400).json({ error: 'Session missing or invalid redirect_uri' })
+    }
+    return passport.authenticate('openidconnect', {
+      state: {
+        returnToExtension: true,
+        extensionId,
+        extensionCodeChallenge,
+        extensionCodeChallengeMethod,
+        extensionState,
+        extensionRedirectUri,
+      },
+    })(req, res, next)
   })
 
   router.post('/login/extension/confirm', async (req, res) => {
@@ -576,11 +599,29 @@ const createAuthRouter = ({
       }
 
       if (returnToExtension) {
+        const extensionId = passportState.extensionId
+        const extensionCodeChallenge = passportState.extensionCodeChallenge
+        const extensionCodeChallengeMethod = passportState.extensionCodeChallengeMethod
+        const extensionState = passportState.extensionState
+        const extensionRedirectUri = passportState.extensionRedirectUri
+        if (!isExtensionIdAllowed(extensionId)
+          || !extensionCodeChallenge
+          || extensionCodeChallengeMethod !== 'S256'
+          || !extensionState
+          || !isAllowedExtensionRedirectUri(extensionRedirectUri)) {
+          logger.warn('Extension OIDC callback missing PKCE details in state')
+          return redirectWithLoginFailed(res)
+        }
         return req.login(user, (loginErr) => {
           if (loginErr) {
             logger.error('req.login failed after extension OIDC', { errorMessage: loginErr?.message })
             return redirectWithLoginFailed(res)
           }
+          req.session.extensionId = extensionId
+          req.session.extensionCodeChallenge = extensionCodeChallenge
+          req.session.extensionCodeChallengeMethod = extensionCodeChallengeMethod
+          req.session.extensionState = extensionState
+          req.session.extensionRedirectUri = extensionRedirectUri
           return res.redirect(`${authRouteBaseUrl}/login/extension`)
         })
       }

--- a/packages/back/test/tests/users/auth/extension-login-view.js
+++ b/packages/back/test/tests/users/auth/extension-login-view.js
@@ -1,0 +1,248 @@
+'use strict'
+
+const { expect } = require('chai')
+const crypto = require('crypto')
+const express = require('express')
+const request = require('supertest')
+const passport = require('passport')
+const { test } = require('cascade-test')
+const { createAuthRouter } = require('../../../../routes/auth')
+
+const ALLOWED_EXTENSION_ID = 'abcdefghijklmnopabcdefghijklmnop'
+const ALLOWED_REDIRECT_URI = `chrome-extension://${ALLOWED_EXTENSION_ID}/auth-callback.html`
+
+const generatePrivateKey = () => {
+  const { privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 })
+  return privateKey.export({ type: 'pkcs8', format: 'pem' })
+}
+
+const baseConfig = (privateKeyPem) => ({
+  frontendURL: 'https://fomoplayer.com',
+  apiOrigin: 'https://fomoplayer.com',
+  allowedOrigins: [],
+  allowedOriginRegexes: [],
+  isPreviewEnv: false,
+  previewAllowedGoogleSubs: [],
+  extensionOauthAllowedIds: [ALLOWED_EXTENSION_ID],
+  extensionOauthAllowedRedirectPatterns: [/^chrome-extension:\/\/[a-p]{32}\/auth-callback\.html$/],
+  internalAuthHandoffPrivateKey: privateKeyPem,
+  internalAuthHandoffKeyId: 'test-kid',
+  internalAuthHandoffIssuer: 'https://fomoplayer.com',
+  internalAuthApiAudience: 'https://api.fomoplayer.com',
+  extensionAccessTokenTtlSeconds: 900,
+  extensionRefreshTokenTtlSeconds: 60,
+})
+
+const buildAppWithSession = (session = {}) => {
+  const app = express()
+  let sessionStore = { ...session }
+  app.use((req, _, next) => {
+    const proxy = new Proxy(
+      {},
+      {
+        get: (_t, key) => sessionStore[key],
+        set: (_t, key, value) => {
+          sessionStore[key] = value
+          return true
+        },
+        deleteProperty: (_t, key) => {
+          delete sessionStore[key]
+          return true
+        },
+        has: (_t, key) => key in sessionStore,
+        ownKeys: () => Reflect.ownKeys(sessionStore),
+        getOwnPropertyDescriptor: (_t, key) => Object.getOwnPropertyDescriptor(sessionStore, key),
+      },
+    )
+    req.session = proxy
+    const isAuthenticated = Boolean(session.userId)
+    req.isAuthenticated = () => isAuthenticated
+    if (isAuthenticated) req.user = { id: session.userId }
+    // Simulate passport's session.regenerate() inside req.login() — wipes prior data.
+    req.login = (_, cb) => {
+      sessionStore = {}
+      cb()
+    }
+    next()
+  })
+  app.use('/api/auth', createAuthRouter({ config: baseConfig(generatePrivateKey()) }))
+  return { app, getSession: () => sessionStore }
+}
+
+const withPatchedPassportAuthenticate = async (authenticateImpl, run) => {
+  const original = passport.authenticate
+  passport.authenticate = authenticateImpl
+  try {
+    return await run()
+  } finally {
+    passport.authenticate = original
+  }
+}
+
+test({
+  'GET /login/extension/google carries extension PKCE fields via OIDC state': async () => {
+    const calls = []
+    const { app } = buildAppWithSession({
+      extensionId: ALLOWED_EXTENSION_ID,
+      extensionCodeChallenge: 'challenge-123',
+      extensionCodeChallengeMethod: 'S256',
+      extensionState: 'state-123',
+      extensionRedirectUri: ALLOWED_REDIRECT_URI,
+    })
+    const response = await withPatchedPassportAuthenticate((strategy, options) => {
+      calls.push({ strategy, options })
+      return (_, res) => res.status(204).end()
+    }, async () => request(app).get('/api/auth/login/extension/google'))
+
+    expect(response.status).to.equal(204)
+    expect(calls).to.have.length(1)
+    expect(calls[0].strategy).to.equal('openidconnect')
+    expect(calls[0].options).to.deep.equal({
+      state: {
+        returnToExtension: true,
+        extensionId: ALLOWED_EXTENSION_ID,
+        extensionCodeChallenge: 'challenge-123',
+        extensionCodeChallengeMethod: 'S256',
+        extensionState: 'state-123',
+        extensionRedirectUri: ALLOWED_REDIRECT_URI,
+      },
+    })
+  },
+
+  'GET /login/extension/google rejects missing extensionId in session': async () => {
+    let called = false
+    const { app } = buildAppWithSession({
+      extensionCodeChallenge: 'challenge-123',
+      extensionCodeChallengeMethod: 'S256',
+      extensionState: 'state-123',
+      extensionRedirectUri: ALLOWED_REDIRECT_URI,
+    })
+    const response = await withPatchedPassportAuthenticate(() => {
+      called = true
+      return (_, res) => res.status(204).end()
+    }, async () => request(app).get('/api/auth/login/extension/google'))
+
+    expect(response.status).to.equal(400)
+    expect(response.body).to.deep.equal({ error: 'Session missing or invalid extensionId' })
+    expect(called).to.equal(false)
+  },
+
+  'GET /login/extension/google rejects missing PKCE params in session': async () => {
+    let called = false
+    const { app } = buildAppWithSession({
+      extensionId: ALLOWED_EXTENSION_ID,
+      extensionRedirectUri: ALLOWED_REDIRECT_URI,
+    })
+    const response = await withPatchedPassportAuthenticate(() => {
+      called = true
+      return (_, res) => res.status(204).end()
+    }, async () => request(app).get('/api/auth/login/extension/google'))
+
+    expect(response.status).to.equal(400)
+    expect(response.body).to.deep.equal({ error: 'Session missing PKCE parameters' })
+    expect(called).to.equal(false)
+  },
+
+  'GET /login/extension/google rejects missing redirect_uri in session': async () => {
+    let called = false
+    const { app } = buildAppWithSession({
+      extensionId: ALLOWED_EXTENSION_ID,
+      extensionCodeChallenge: 'challenge-123',
+      extensionCodeChallengeMethod: 'S256',
+      extensionState: 'state-123',
+    })
+    const response = await withPatchedPassportAuthenticate(() => {
+      called = true
+      return (_, res) => res.status(204).end()
+    }, async () => request(app).get('/api/auth/login/extension/google'))
+
+    expect(response.status).to.equal(400)
+    expect(response.body).to.deep.equal({ error: 'Session missing or invalid redirect_uri' })
+    expect(called).to.equal(false)
+  },
+
+  'GET /login/google/return restores extension PKCE session and redirects back to /login/extension': async () => {
+    const { app, getSession } = buildAppWithSession({})
+    const response = await withPatchedPassportAuthenticate((strategy, handler) => {
+      return (req, res, next) => {
+        expect(strategy).to.equal('openidconnect')
+        return handler(null, { id: 42 }, {
+          state: {
+            returnToExtension: true,
+            extensionId: ALLOWED_EXTENSION_ID,
+            extensionCodeChallenge: 'challenge-from-oidc',
+            extensionCodeChallengeMethod: 'S256',
+            extensionState: 'state-from-oidc',
+            extensionRedirectUri: ALLOWED_REDIRECT_URI,
+          },
+        })
+      }
+    }, async () =>
+      request(app).get('/api/auth/login/google/return').query({ code: 'oidc-code', state: 'opaque-state' }),
+    )
+
+    expect(response.status).to.equal(302)
+    expect(response.headers.location).to.equal('https://fomoplayer.com/api/auth/login/extension')
+    const sessionStore = getSession()
+    expect(sessionStore.extensionId).to.equal(ALLOWED_EXTENSION_ID)
+    expect(sessionStore.extensionCodeChallenge).to.equal('challenge-from-oidc')
+    expect(sessionStore.extensionCodeChallengeMethod).to.equal('S256')
+    expect(sessionStore.extensionState).to.equal('state-from-oidc')
+    expect(sessionStore.extensionRedirectUri).to.equal(ALLOWED_REDIRECT_URI)
+  },
+
+  'GET /login/google/return extension PKCE session survives passport session regeneration': async () => {
+    const { app, getSession } = buildAppWithSession({
+      extensionId: ALLOWED_EXTENSION_ID,
+      extensionCodeChallenge: 'pre-oidc-challenge',
+      extensionCodeChallengeMethod: 'S256',
+      extensionState: 'pre-oidc-state',
+      extensionRedirectUri: ALLOWED_REDIRECT_URI,
+    })
+    await withPatchedPassportAuthenticate((strategy, handler) => {
+      return (req, res, next) => {
+        return handler(null, { id: 42 }, {
+          state: {
+            returnToExtension: true,
+            extensionId: ALLOWED_EXTENSION_ID,
+            extensionCodeChallenge: 'challenge-from-oidc',
+            extensionCodeChallengeMethod: 'S256',
+            extensionState: 'state-from-oidc',
+            extensionRedirectUri: ALLOWED_REDIRECT_URI,
+          },
+        })
+      }
+    }, async () =>
+      request(app).get('/api/auth/login/google/return').query({ code: 'oidc-code', state: 'opaque-state' }),
+    )
+
+    const sessionStore = getSession()
+    expect(sessionStore.extensionId).to.equal(ALLOWED_EXTENSION_ID)
+    expect(sessionStore.extensionCodeChallenge).to.equal('challenge-from-oidc')
+    expect(sessionStore.extensionCodeChallengeMethod).to.equal('S256')
+    expect(sessionStore.extensionState).to.equal('state-from-oidc')
+    expect(sessionStore.extensionRedirectUri).to.equal(ALLOWED_REDIRECT_URI)
+  },
+
+  'GET /login/google/return rejects extension OIDC callback with disallowed extensionId in state': async () => {
+    const { app } = buildAppWithSession({})
+    const response = await withPatchedPassportAuthenticate((strategy, handler) => {
+      return (req, res, next) =>
+        handler(null, { id: 42 }, {
+          state: {
+            returnToExtension: true,
+            extensionId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            extensionCodeChallenge: 'challenge-from-oidc',
+            extensionCodeChallengeMethod: 'S256',
+            extensionState: 'state-from-oidc',
+            extensionRedirectUri: ALLOWED_REDIRECT_URI,
+          },
+        })
+    }, async () =>
+      request(app).get('/api/auth/login/google/return').query({ code: 'oidc-code', state: 'opaque-state' }),
+    )
+
+    expect(response.status).to.equal(302)
+    expect(response.headers.location).to.match(/loginFailed=true/)
+  },
+})


### PR DESCRIPTION
## Summary

- Extension login was failing at `POST /api/auth/login/extension/confirm` with `Session missing or invalid extensionId` because Passport 0.7's `req.login()` regenerates the session for fixation protection, wiping the PKCE fields (`extensionId`, `codeChallenge`, `state`, `redirect_uri`) that the GET `/login/extension` handler stashed before the Google round-trip.
- Forwarded the PKCE fields through Passport's OIDC `state` payload from `/login/extension/google`, and rehydrate them in the `/login/google/return` callback after `req.login()` — same shape the CLI flow already uses (`auth.js:565-575`).
- Added `extension-login-view.js` with a regression test that fakes `req.login` to empty the session, mirroring the existing `cli-login-view.js` "PKCE session survives passport session regeneration" test.

## Test plan

- [x] `cd packages/back && yarn test --regex extension-login-view` — 7/7 pass, including "extension PKCE session survives passport session regeneration"
- [x] `yarn test --regex "extension-token|extension-login-view|cli-login-view"` — 36/36 pass (no regression in the existing extension or CLI suites)
- [ ] Manual: with a signed-out browser, click the extension's Login → Continue with Google → land on the Allow page after the OIDC round-trip → click Allow → redirect lands on `chrome-extension://<id>/auth-callback.html?code=…&state=…`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation for extension authentication to prevent invalid configuration attempts.
  * Improved error handling for missing or invalid authentication parameters during extension login.
  * Strengthened extension login callback processing with stricter security checks.

* **Tests**
  * Added comprehensive test suite for extension authentication workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->